### PR TITLE
Isolated measurement for reliable and stable benchmarking results

### DIFF
--- a/Gauge.hs
+++ b/Gauge.hs
@@ -65,5 +65,5 @@ benchmarkWith' cfg bm = do
   initializeTime
   withConfig cfg $ do
     _ <- note "benchmarking...\n"
-    Analysed rpt <- runAndAnalyseOne 0 "function" bm
+    Analysed rpt <- runAndAnalyseOne "function" bm
     return rpt

--- a/Gauge.hs
+++ b/Gauge.hs
@@ -65,5 +65,4 @@ benchmarkWith' cfg bm = do
   initializeTime
   withConfig cfg $ do
     _ <- note "benchmarking...\n"
-    Analysed rpt <- runAndAnalyseOne "function" bm
-    return rpt
+    runAndAnalyseOne "function" bm

--- a/Gauge/Analysis.hs
+++ b/Gauge/Analysis.hs
@@ -18,13 +18,13 @@
 -- module.
 
 module Gauge.Analysis
-    ( analyseOne
-    , Outliers(..)
+    ( Outliers(..)
     , OutlierEffect(..)
     , OutlierVariance(..)
     , SampleAnalysis(..)
     , analyseSample
     , scale
+    , analyseBenchmark
     , analyseMean
     , countOutliers
     , classifyOutliers
@@ -267,8 +267,8 @@ noteOutliers o = do
     check (highSevere o) 0 "high severe"
 
 -- | Analyse a single benchmark.
-analyseOne :: String -> V.Vector Measured -> Gauge Report
-analyseOne desc meas = do
+analyseBenchmark :: String -> V.Vector Measured -> Gauge Report
+analyseBenchmark desc meas = do
   Config{..} <- askConfig
   _ <- prolix "analysing with %d resamples\n" resamples
   erp <- analyseSample desc meas

--- a/Gauge/Analysis.hs
+++ b/Gauge/Analysis.hs
@@ -13,9 +13,13 @@
 --
 -- Analysis code for benchmarks.
 
+-- XXX Do we really want to expose this module to users? This is all internal.
+-- Most of the exports are not even used by Gauge itself outside of this
+-- module.
+
 module Gauge.Analysis
-    (
-      Outliers(..)
+    ( analyseOne
+    , Outliers(..)
     , OutlierEffect(..)
     , OutlierVariance(..)
     , SampleAnalysis(..)
@@ -35,8 +39,8 @@ module Gauge.Analysis
 import Data.Monoid
 
 import Control.Arrow (second)
-import Control.Monad (unless, when)
-import Gauge.IO.Printf (note, prolix)
+import Control.Monad (forM_, unless, when)
+import Gauge.IO.Printf (note, printError, prolix, rewindClearLine)
 import Gauge.Measurement (secs, threshold)
 import Gauge.Monad (Gauge, getGen, getOverhead, askConfig, gaugeIO)
 import Gauge.Types
@@ -48,8 +52,10 @@ import Statistics.Regression (bootstrapRegress, olsRegress)
 import Statistics.Resampling (Estimator(..),resample)
 import Statistics.Sample (mean)
 import Statistics.Sample.KernelDensity (kde)
-import Statistics.Types (Sample)
+import Statistics.Types (Sample, Estimate(..),ConfInt(..),confidenceInterval
+                        ,cl95,confidenceLevel)
 import System.Random.MWC (GenIO)
+import Text.Printf (printf)
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Vector as V
@@ -259,3 +265,69 @@ noteOutliers o = do
     check (lowMild o) 1 "low mild"
     check (highMild o) 1 "high mild"
     check (highSevere o) 0 "high severe"
+
+-- | Analyse a single benchmark.
+analyseOne :: String -> V.Vector Measured -> Gauge DataRecord
+analyseOne desc meas = do
+  Config{..} <- askConfig
+  _ <- prolix "analysing with %d resamples\n" resamples
+  erp <- analyseSample desc meas
+  case erp of
+    Left err -> printError "*** Error: %s\n" err
+    Right rpt@Report{..} -> do
+        let SampleAnalysis{..} = reportAnalysis
+            OutlierVariance{..} = anOutlierVar
+            wibble = printOverallEffect ovEffect
+            (builtin, others) = splitAt 1 anRegress
+        case displayMode of
+            StatsTable -> do
+              _ <- note "%sbenchmarked %s\n" rewindClearLine desc
+              let r2 n = printf "%.3f R\178" n
+              forM_ builtin $ \Regression{..} ->
+                case Map.lookup "iters" regCoeffs of
+                  Nothing -> return ()
+                  Just t  -> bs secs "time" t >> bs r2 "" regRSquare
+              bs secs "mean" anMean
+              bs secs "std dev" anStdDev
+              forM_ others $ \Regression{..} -> do
+                _ <- bs r2 (regResponder ++ ":") regRSquare
+                forM_ (Map.toList regCoeffs) $ \(prd,val) ->
+                  bs (printf "%.3g") ("  " ++ prd) val
+              --writeCsv
+              --  (desc,
+              --   estPoint anMean,   fst $ confidenceInterval anMean,   snd $ confidenceInterval anMean,
+              --   estPoint anStdDev, fst $ confidenceInterval anStdDev, snd $ confidenceInterval anStdDev
+              -- )
+              when (verbosity == Verbose || (ovEffect > Slight && verbosity > Quiet)) $ do
+                when (verbosity == Verbose) $ noteOutliers reportOutliers
+                _ <- note "variance introduced by outliers: %d%% (%s)\n"
+                     (round (ovFraction * 100) :: Int) wibble
+                return ()
+              _ <- note "\n"
+              pure ()
+            Condensed -> do
+              _ <- note "%s%-40s " rewindClearLine desc
+              bsSmall secs "mean" anMean
+              bsSmall secs "( +-" anStdDev
+              _ <- note ")\n"
+              pure ()
+
+        return (Analysed rpt)
+      where bs :: (Double -> String) -> String -> Estimate ConfInt Double -> Gauge ()
+            bs f metric e@Estimate{..} =
+              note "%-20s %-10s (%s .. %s%s)\n" metric
+                   (f estPoint) (f $ fst $ confidenceInterval e) (f $ snd $ confidenceInterval e)
+                   (let cl = confIntCL estError
+                        str | cl == cl95 = ""
+                            | otherwise  = printf ", ci %.3f" (confidenceLevel cl)
+                    in str
+                   )
+            bsSmall :: (Double -> String) -> String -> Estimate ConfInt Double -> Gauge ()
+            bsSmall f metric Estimate{..} =
+              note "%s %-10s" metric (f estPoint)
+
+printOverallEffect :: OutlierEffect -> String
+printOverallEffect Unaffected = "unaffected"
+printOverallEffect Slight     = "slightly inflated"
+printOverallEffect Moderate   = "moderately inflated"
+printOverallEffect Severe     = "severely inflated"

--- a/Gauge/Analysis.hs
+++ b/Gauge/Analysis.hs
@@ -32,7 +32,7 @@ module Gauge.Analysis
     ) where
 
 -- Temporary: to support pre-AMP GHC 7.8.4:
-import Data.Monoid 
+import Data.Monoid
 
 import Control.Arrow (second)
 import Control.Monad (unless, when)
@@ -136,11 +136,10 @@ scale f s@SampleAnalysis{..} = s {
                                }
 
 -- | Perform an analysis of a measurement.
-analyseSample :: Int            -- ^ Experiment number.
-              -> String         -- ^ Experiment name.
+analyseSample :: String            -- ^ Experiment name.
               -> V.Vector Measured -- ^ Sample data.
               -> Gauge (Either String Report)
-analyseSample i name meas = do
+analyseSample name meas = do
   Config{..} <- askConfig
   overhead <- getOverhead
   let ests      = [Mean,StdDev]
@@ -172,8 +171,7 @@ analyseSample i name meas = do
                  , anOutlierVar = ov
                  }
       return $ Right $ Report
-        { reportNumber   = i
-        , reportName     = name
+        { reportName     = name
         , reportKeys     = measureKeys
         , reportMeasured = meas
         , reportAnalysis = an

--- a/Gauge/Analysis.hs
+++ b/Gauge/Analysis.hs
@@ -267,7 +267,7 @@ noteOutliers o = do
     check (highSevere o) 0 "high severe"
 
 -- | Analyse a single benchmark.
-analyseOne :: String -> V.Vector Measured -> Gauge DataRecord
+analyseOne :: String -> V.Vector Measured -> Gauge Report
 analyseOne desc meas = do
   Config{..} <- askConfig
   _ <- prolix "analysing with %d resamples\n" resamples
@@ -312,7 +312,7 @@ analyseOne desc meas = do
               _ <- note ")\n"
               pure ()
 
-        return (Analysed rpt)
+        return rpt
       where bs :: (Double -> String) -> String -> Estimate ConfInt Double -> Gauge ()
             bs f metric e@Estimate{..} =
               note "%-20s %-10s (%s .. %s%s)\n" metric

--- a/Gauge/Internal.hs
+++ b/Gauge/Internal.hs
@@ -21,7 +21,7 @@ import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Control.Monad (foldM, void, when)
 import Data.Int (Int64)
-import Gauge.Analysis (analyseOne)
+import Gauge.Analysis (analyseBenchmark)
 import Gauge.IO.Printf (note, prolix)
 import Gauge.Measurement (runBenchmark, runBenchmarkable_, secs)
 import Gauge.Monad (Gauge, finallyGauge, askConfig, gaugeIO)
@@ -42,7 +42,7 @@ runOne bm = do
 runAndAnalyseOne :: String -> Benchmarkable -> Gauge Report
 runAndAnalyseOne desc bm = do
   meas <- runOne bm
-  analyseOne desc meas
+  analyseBenchmark desc meas
 
 -- | Run, and analyse, one or more benchmarks.
 runAndAnalyse :: (String -> Bool) -- ^ A predicate that chooses

--- a/Gauge/Internal.hs
+++ b/Gauge/Internal.hs
@@ -42,11 +42,11 @@ runOne desc bm = do
   return (Measurement desc meas)
 
 -- | Analyse a single benchmark.
-analyseOne :: Int -> String -> V.Vector Measured -> Gauge DataRecord
-analyseOne i desc meas = do
+analyseOne :: String -> V.Vector Measured -> Gauge DataRecord
+analyseOne desc meas = do
   Config{..} <- askConfig
   _ <- prolix "analysing with %d resamples\n" resamples
-  erp <- analyseSample i desc meas
+  erp <- analyseSample desc meas
   case erp of
     Left err -> printError "*** Error: %s\n" err
     Right rpt@Report{..} -> do
@@ -109,10 +109,10 @@ printOverallEffect Severe     = "severely inflated"
 
 
 -- | Run a single benchmark and analyse its performance.
-runAndAnalyseOne :: Int -> String -> Benchmarkable -> Gauge DataRecord
-runAndAnalyseOne i desc bm = do
+runAndAnalyseOne :: String -> Benchmarkable -> Gauge DataRecord
+runAndAnalyseOne desc bm = do
   Measurement _ meas <- runOne desc bm
-  analyseOne i desc meas
+  analyseOne desc meas
 
 -- | Run, and analyse, one or more benchmarks.
 runAndAnalyse :: (String -> Bool) -- ^ A predicate that chooses
@@ -130,7 +130,7 @@ runAndAnalyse select bs = do
   gaugeIO $ hSetBuffering stdout NoBuffering
   for select bs $ \idx desc bm -> do
     _ <- note "benchmarking %s" desc
-    Analysed _ <- runAndAnalyseOne idx desc bm
+    Analysed _ <- runAndAnalyseOne desc bm
     return ()
     --unless (idx == 0) $
     --  liftIO $ hPutStr handle ", "

--- a/Gauge/Internal.hs
+++ b/Gauge/Internal.hs
@@ -33,13 +33,13 @@ import System.IO (hSetBuffering, BufferMode(..), stdout)
 import Text.Printf (printf)
 
 -- | Run a single benchmark.
-runOne :: Int -> String -> Benchmarkable -> Gauge DataRecord
-runOne i desc bm = do
+runOne :: String -> Benchmarkable -> Gauge DataRecord
+runOne desc bm = do
   Config{..} <- askConfig
   (meas,timeTaken) <- gaugeIO $ runBenchmark bm timeLimit
   when (timeTaken > timeLimit * 1.25) .
     void $ prolix "measurement took %s\n" (secs timeTaken)
-  return (Measurement i desc meas)
+  return (Measurement desc meas)
 
 -- | Analyse a single benchmark.
 analyseOne :: Int -> String -> V.Vector Measured -> Gauge DataRecord
@@ -111,7 +111,7 @@ printOverallEffect Severe     = "severely inflated"
 -- | Run a single benchmark and analyse its performance.
 runAndAnalyseOne :: Int -> String -> Benchmarkable -> Gauge DataRecord
 runAndAnalyseOne i desc bm = do
-  Measurement _ _ meas <- runOne i desc bm
+  Measurement _ meas <- runOne desc bm
   analyseOne i desc meas
 
 -- | Run, and analyse, one or more benchmarks.

--- a/Gauge/Internal.hs
+++ b/Gauge/Internal.hs
@@ -29,18 +29,18 @@ import Gauge.Types hiding (measure)
 import System.IO (hSetBuffering, BufferMode(..), stdout)
 
 -- | Run a single benchmark.
-runOne :: String -> Benchmarkable -> Gauge DataRecord
-runOne desc bm = do
+runOne :: Benchmarkable -> Gauge DataRecord
+runOne bm = do
   Config{..} <- askConfig
   (meas,timeTaken) <- gaugeIO $ runBenchmark bm timeLimit
   when (timeTaken > timeLimit * 1.25) .
     void $ prolix "measurement took %s\n" (secs timeTaken)
-  return (Measurement desc meas)
+  return (Measurement meas)
 
 -- | Run a single benchmark and analyse its performance.
 runAndAnalyseOne :: String -> Benchmarkable -> Gauge DataRecord
 runAndAnalyseOne desc bm = do
-  Measurement _ meas <- runOne desc bm
+  Measurement meas <- runOne bm
   analyseOne desc meas
 
 -- | Run, and analyse, one or more benchmarks.

--- a/Gauge/Types.hs
+++ b/Gauge/Types.hs
@@ -724,10 +724,10 @@ instance NFData Report where
       rnf reportMeasured `seq` rnf reportAnalysis `seq` rnf reportOutliers `seq`
       rnf reportKDEs
 
-data DataRecord = Measurement String (V.Vector Measured)
+data DataRecord = Measurement (V.Vector Measured)
                 | Analysed Report
                 deriving (Eq, Read, Show, Typeable, Generic)
 
 instance NFData DataRecord where
-  rnf (Measurement n v) = rnf n `seq` rnf v
-  rnf (Analysed r)      = rnf r
+  rnf (Measurement v) = rnf v
+  rnf (Analysed r)    = rnf r

--- a/Gauge/Types.hs
+++ b/Gauge/Types.hs
@@ -726,10 +726,10 @@ instance NFData Report where
       rnf reportMeasured `seq` rnf reportAnalysis `seq` rnf reportOutliers `seq`
       rnf reportKDEs
 
-data DataRecord = Measurement Int String (V.Vector Measured)
+data DataRecord = Measurement String (V.Vector Measured)
                 | Analysed Report
                 deriving (Eq, Read, Show, Typeable, Generic)
 
 instance NFData DataRecord where
-  rnf (Measurement i n v) = rnf i `seq` rnf n `seq` rnf v
-  rnf (Analysed r)        = rnf r
+  rnf (Measurement n v) = rnf n `seq` rnf v
+  rnf (Analysed r)      = rnf r

--- a/Gauge/Types.hs
+++ b/Gauge/Types.hs
@@ -71,7 +71,6 @@ module Gauge.Types
     , KDE(..)
     , Report(..)
     , SampleAnalysis(..)
-    , DataRecord(..)
     ) where
 
 -- Temporary: to support pre-AMP GHC 7.8.4:
@@ -723,11 +722,3 @@ instance NFData Report where
       rnf reportName `seq` rnf reportKeys `seq`
       rnf reportMeasured `seq` rnf reportAnalysis `seq` rnf reportOutliers `seq`
       rnf reportKDEs
-
-data DataRecord = Measurement (V.Vector Measured)
-                | Analysed Report
-                deriving (Eq, Read, Show, Typeable, Generic)
-
-instance NFData DataRecord where
-  rnf (Measurement v) = rnf v
-  rnf (Analysed r)    = rnf r

--- a/Gauge/Types.hs
+++ b/Gauge/Types.hs
@@ -136,6 +136,12 @@ data Config = Config {
     , timeLimit    :: Double
       -- ^ Number of seconds to run a single benchmark.  (In practice,
       -- execution time will very slightly exceed this limit.)
+    , measureOnly  :: Maybe FilePath
+    -- ^ Just measure the given benchmark and place the raw output in this
+    -- file, do not analyse and generate a report.
+    , measureWith  :: Maybe FilePath
+    -- ^ Specify the path of the benchmarking program to use (this program
+    -- itself) for measuring the benchmarks in a separate process.
     , resamples    :: Int
       -- ^ Number of resamples to perform when bootstrapping.
     , regressions  :: [([String], String)]

--- a/Gauge/Types.hs
+++ b/Gauge/Types.hs
@@ -702,9 +702,7 @@ instance NFData KDE where
 
 -- | Report of a sample analysis.
 data Report = Report {
-      reportNumber   :: Int
-      -- ^ A simple index indicating that this is the /n/th report.
-    , reportName     :: String
+      reportName     :: String
       -- ^ The name of this report.
     , reportKeys     :: [String]
       -- ^ See 'measureKeys'.
@@ -722,7 +720,7 @@ data Report = Report {
 
 instance NFData Report where
     rnf Report{..} =
-      rnf reportNumber `seq` rnf reportName `seq` rnf reportKeys `seq`
+      rnf reportName `seq` rnf reportKeys `seq`
       rnf reportMeasured `seq` rnf reportAnalysis `seq` rnf reportOutliers `seq`
       rnf reportKDEs
 

--- a/gauge.cabal
+++ b/gauge.cabal
@@ -83,6 +83,8 @@ library
     deepseq >= 1.1.0.0,
     mwc-random >= 0.8.0.3,
     vector >= 0.7.1,
+    process,
+    directory,
 
     -- formely statistics dependency that we need
     math-functions


### PR DESCRIPTION
Add a ``--measure-only`` option and a ``--measure-with`` option
    
The ``--measure-only`` option just measures a benchmark and places the output in a
    specified temporary file. The file is a means of communication between two
    processes. I implemented is using a file but we can use stdout as well instead
    of file.
    
The ``--measure-with`` option is used to run each benchmark in a separate process. We
    specify the path of the benchmark executable itself as an argument to this
    option, which is a bit clumsy. The problem is that there is no portable way to
    figure the path of the running executable. It is easy to do on Unices but not
    on Windows. Therefore the strategy used here is to have the user specify it on
    the command line. For example:

```    
stack bench --benchmark-arguments "--measure-with .stack-work/dist/x86_64-osx/Cabal-2.0.0.2/build/benchmarks/benchmarks transformation/map/"
```
    
With isolation the measurement is accurate, previous benchmarks do not affect the
later ones and the variance too has got reduced drastically.

Running all the benchmarks in a single process:

```
$ stack bench --benchmark-arguments "transformation/map/"

benchmarked transformation/map/machines
time                 26.45 ms   (25.39 ms .. 27.37 ms)
                     0.993 R²   (0.983 R² .. 0.998 R²)
mean                 21.91 ms   (19.31 ms .. 23.21 ms)
std dev              3.364 ms   (1.938 ms .. 5.432 ms)
variance introduced by outliers: 61% (severely inflated)

benchmarked transformation/map/asyncly
time                 22.47 ms   (21.75 ms .. 23.26 ms)
                     0.995 R²   (0.989 R² .. 0.999 R²)
mean                 18.09 ms   (16.85 ms .. 19.17 ms)
std dev              2.266 ms   (1.638 ms .. 3.272 ms)
variance introduced by outliers: 51% (severely inflated)

benchmarked transformation/map/streaming
time                 15.27 ms   (14.38 ms .. 15.95 ms)
                     0.978 R²   (0.939 R² .. 0.998 R²)
mean                 12.22 ms   (11.03 ms .. 13.19 ms)
std dev              2.118 ms   (1.432 ms .. 3.074 ms)
variance introduced by outliers: 71% (severely inflated)

benchmarked transformation/map/pipes
time                 24.94 ms   (23.46 ms .. 26.56 ms)
                     0.990 R²   (0.977 R² .. 0.997 R²)
mean                 19.36 ms   (17.59 ms .. 20.74 ms)
std dev              2.854 ms   (1.717 ms .. 4.397 ms)
variance introduced by outliers: 55% (severely inflated)

benchmarked transformation/map/conduit
time                 29.37 ms   (27.70 ms .. 31.61 ms)
                     0.988 R²   (0.969 R² .. 0.999 R²)
mean                 22.36 ms   (19.86 ms .. 24.47 ms)
std dev              3.627 ms   (2.334 ms .. 4.828 ms)
variance introduced by outliers: 53% (severely inflated)

benchmarked transformation/map/list-transformer
time                 65.83 ms   (55.01 ms .. 73.50 ms)
                     0.974 R²   (0.935 R² .. 0.998 R²)
mean                 55.83 ms   (50.12 ms .. 60.75 ms)
std dev              7.470 ms   (4.214 ms .. 12.24 ms)
variance introduced by outliers: 36% (moderately inflated)

```

With isolation:

```
$ stack bench --benchmark-arguments "--measure-with .stack-work//dist/x86_64-osx/Cabal-2.0.0.2/bu

benchmarked transformation/map/machines
time                 26.86 ms   (26.44 ms .. 27.38 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 27.06 ms   (26.76 ms .. 27.38 ms)
std dev              601.6 μs   (474.9 μs .. 793.0 μs)

benchmarked transformation/map/asyncly
time                 21.85 ms   (21.36 ms .. 22.48 ms)
                     0.997 R²   (0.993 R² .. 0.999 R²)
mean                 21.79 ms   (21.55 ms .. 22.10 ms)
std dev              584.4 μs   (431.6 μs .. 844.4 μs)

benchmarked transformation/map/streaming
time                 14.25 ms   (13.63 ms .. 14.78 ms)
                     0.993 R²   (0.985 R² .. 0.997 R²)
mean                 15.23 ms   (14.86 ms .. 16.02 ms)
std dev              1.230 ms   (614.0 μs .. 2.058 ms)
variance introduced by outliers: 34% (moderately inflated)

benchmarked transformation/map/pipes
time                 25.14 ms   (20.44 ms .. 31.76 ms)
                     0.890 R²   (0.809 R² .. 0.995 R²)
mean                 22.60 ms   (21.67 ms .. 25.32 ms)
std dev              3.157 ms   (919.2 μs .. 5.592 ms)
variance introduced by outliers: 55% (severely inflated)

benchmarked transformation/map/conduit
time                 25.16 ms   (24.47 ms .. 25.79 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 25.01 ms   (24.71 ms .. 25.34 ms)
std dev              650.0 μs   (523.6 μs .. 836.8 μs)

benchmarked transformation/map/list-transformer
time                 61.41 ms   (60.15 ms .. 63.74 ms)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 60.31 ms   (59.54 ms .. 61.29 ms)
std dev              1.448 ms   (836.8 μs .. 2.457 ms)

Benchmark benchmarks: FINISH
```

Notice how the variance is not even reported in most of the benchmarks and has been reduced in the streaming benchmark, and remains the same for pipes. Standard deviation has drastically come down. Also, the conduit and list-transformer benchmarks are not inflated anymore, and always come out with the same measurement.