### PR TITLE
Rejiggle measurement framework to get os data at the nanoseconds

### DIFF
--- a/cbits/gauge-time.h
+++ b/cbits/gauge-time.h
@@ -1,0 +1,19 @@
+#ifndef GAUGE_TIME_H
+
+#include <stdint.h>
+
+/* 24 bytes */
+struct gauge_time {
+    uint64_t clock_nanosecs;
+    uint64_t cpu_nanosecs;
+    uint64_t rdtsc;
+};
+
+/* multiplicator to rescale from X to nanoseconds */
+const uint64_t ref_nanosecond    = 1;
+const uint64_t ref_100nanosecond = 100;
+const uint64_t ref_microsecond   = 1000;
+const uint64_t ref_millisecond   = 1000000;
+const uint64_t ref_second        = 1000000000;
+
+#endif

--- a/cbits/time-osx.c
+++ b/cbits/time-osx.c
@@ -33,8 +33,10 @@ void gauge_record(struct gauge_time *tr)
 
     tr->clock_nanosecs = scale64(mach_absolute_time(), timebase_info.numer, timebase_info.denom);
 
-    tr->cpu_nanosecs = (((uint64_t) thread_info_data.seconds) * ref_second) +
-                       (((uint64_t) thread_info_data.microseconds) * ref_microsecond)
+    tr->cpu_nanosecs = (((uint64_t) thread_info_data.user_time.seconds) * ref_second) +
+                       (((uint64_t) thread_info_data.user_time.microseconds) * ref_microsecond) +
+                       (((uint64_t) thread_info_data.system_time.seconds) * ref_second) +
+                       (((uint64_t) thread_info_data.system_time.microseconds) * ref_microsecond)
     tr->rdtsc = 0;
 }
 

--- a/cbits/time-osx.c
+++ b/cbits/time-osx.c
@@ -36,7 +36,7 @@ void gauge_record(struct gauge_time *tr)
     tr->cpu_nanosecs = (((uint64_t) thread_info_data.user_time.seconds) * ref_second) +
                        (((uint64_t) thread_info_data.user_time.microseconds) * ref_microsecond) +
                        (((uint64_t) thread_info_data.system_time.seconds) * ref_second) +
-                       (((uint64_t) thread_info_data.system_time.microseconds) * ref_microsecond)
+                       (((uint64_t) thread_info_data.system_time.microseconds) * ref_microsecond);
     tr->rdtsc = 0;
 }
 

--- a/cbits/time-posix.c
+++ b/cbits/time-posix.c
@@ -1,7 +1,38 @@
 #include <time.h>
+#include <stdint.h>
+
+#include <unistd.h>
+#include <asm-generic/unistd.h>
+#include <linux/perf_event.h>
+
+#include "gauge-time.h"
+
+static int gauge_rdtsc_fddev = -1;
 
 void gauge_inittime(void)
 {
+    static struct perf_event_attr attr;
+    attr.type = PERF_TYPE_HARDWARE;
+    attr.config = PERF_COUNT_HW_CPU_CYCLES;
+    gauge_rdtsc_fddev = syscall (__NR_perf_event_open, &attr, 0, -1, -1, 0);
+}
+
+#define timespec_to_uint64(x) (                      \
+        (( ((uint64_t ) (x).tv_sec) * ref_second)) + \
+           ((uint64_t) (x).tv_nsec)                  \
+        )
+
+void gauge_record(struct gauge_time *tr)
+{
+    struct timespec ts, ts2;
+    uint64_t res;
+
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts2);
+
+    tr->clock_nanosecs = timespec_to_uint64(ts);
+    tr->cpu_nanosecs = timespec_to_uint64(ts2);
+    tr->rdtsc = (read (gauge_rdtsc_fddev, &res, sizeof(res)) < sizeof(res)) ? 0 : res;
 }
 
 double gauge_gettime(void)

--- a/cbits/time-windows.c
+++ b/cbits/time-windows.c
@@ -69,7 +69,8 @@ void gauge_record(struct gauge_time *tr)
 
     time = to_quad_100ns(user) + to_quad_100ns(kernel);
 
-    tr->clock_nanosecs = (li.QuadPart - firstClock.QuadPart) / freq.QuadPart;
+    tr->clock_nanosecs = (li.QuadPart / freq.QuadPart * ref_second) +
+                         ((li.QuadPart % freq.QuadPart) * ref_second) / freq.QuadPart;
     tr->cpu_nanosecs = time * ref_100nanosecond;
     tr->rdtsc = 0;
 }

--- a/cbits/time-windows.c
+++ b/cbits/time-windows.c
@@ -69,7 +69,7 @@ void gauge_record(struct gauge_time *tr)
 
     time = to_quad_100ns(user) + to_quad_100ns(kernel);
 
-    tr->clock_nanosecs = (li.QuadPart - firstClock.QuadPart) / freq.quadPart;
+    tr->clock_nanosecs = (li.QuadPart - firstClock.QuadPart) / freq.QuadPart;
     tr->cpu_nanosecs = time * ref_100nanosecond;
     tr->rdtsc = 0;
 }

--- a/cbits/time-windows.c
+++ b/cbits/time-windows.c
@@ -15,33 +15,14 @@
 
 #include <windows.h>
 
-#if 0
+#include "gauge-time.h"
 
-void gauge_inittime(void)
-{
-}
-
-double gauge_gettime(void)
-{
-    FILETIME ft;
-    ULARGE_INTEGER li;
-
-    GetSystemTimeAsFileTime(&ft);
-    li.LowPart = ft.dwLowDateTime;
-    li.HighPart = ft.dwHighDateTime;
-
-    return (li.QuadPart - 130000000000000000ull) * 1e-7;
-}
-
-#else
-
+static LARGE_INTEGER freq;
 static double freq_recip;
 static LARGE_INTEGER firstClock;
 
 void gauge_inittime(void)
 {
-    LARGE_INTEGER freq;
-
     if (freq_recip == 0) {
 	QueryPerformanceFrequency(&freq);
 	QueryPerformanceCounter(&firstClock);
@@ -57,8 +38,6 @@ double gauge_gettime(void)
 
     return ((double) (li.QuadPart - firstClock.QuadPart)) * freq_recip;
 }
-
-#endif
 
 static ULONGLONG to_quad_100ns(FILETIME ft)
 {
@@ -77,4 +56,20 @@ double gauge_getcputime(void)
 
     time = to_quad_100ns(user) + to_quad_100ns(kernel);
     return time / 1e7;
+}
+
+void gauge_record(struct gauge_time *tr)
+{
+    LARGE_INTEGER li;
+    FILETIME creation, exit, kernel, user;
+    ULONGLONG time;
+
+    QueryPerformanceCounter(&li);
+    GetProcessTimes(GetCurrentProcess(), &creation, &exit, &kernel, &user);
+
+    time = to_quad_100ns(user) + to_quad_100ns(kernel);
+
+    tr->clock_nanosecs = (li.QuadPart - firstClock.QuadPart) / freq.quadPart;
+    tr->cpu_nanosecs = time * ref_100nanosecond;
+    tr->rdtsc = 0;
 }


### PR DESCRIPTION
Remove use of Double at the os binding level, moving to integrals nanoseconds.

Until a reasonable certainty about exactness is achieved, the previous measurement code is available under a ifdef in Gauge.Measurement.

To keep this PR self contained, the nanoseconds are converted back to Double for now.