### PR TITLE
Fix GC stats for GHC 8.2

### DIFF
--- a/Gauge/Measurement.hs
+++ b/Gauge/Measurement.hs
@@ -201,20 +201,20 @@ getGCStatistics = do
         nsToSecs ns = fromIntegral ns * 1.0E-9
 
     return $ GCStatistics {
-        gcStatsBytesAllocated         = fromIntegral $ gcdetails_allocated_bytes gcdetails
+        gcStatsBytesAllocated         = fromIntegral $ allocated_bytes stats
       , gcStatsNumGcs                 = fromIntegral $ gcs stats
       , gcStatsMaxBytesUsed           = fromIntegral $ max_live_bytes stats
       , gcStatsNumByteUsageSamples    = fromIntegral $ major_gcs stats
       , gcStatsCumulativeBytesUsed    = fromIntegral $ cumulative_live_bytes stats
-      , gcStatsBytesCopied            = fromIntegral $ gcdetails_copied_bytes gcdetails
+      , gcStatsBytesCopied            = fromIntegral $ copied_bytes stats
       , gcStatsCurrentBytesUsed       = fromIntegral $ gcdetails_live_bytes gcdetails
       , gcStatsCurrentBytesSlop       = fromIntegral $ gcdetails_slop_bytes gcdetails
       , gcStatsMaxBytesSlop           = fromIntegral $ max_slop_bytes stats
       , gcStatsPeakMegabytesAllocated = fromIntegral (max_mem_in_use_bytes stats) `quot` (1024*1024)
       , gcStatsMutatorCpuSeconds      = nsToSecs $ mutator_cpu_ns stats
       , gcStatsMutatorWallSeconds     = nsToSecs $ mutator_elapsed_ns stats
-      , gcStatsGcCpuSeconds           = nsToSecs $ gcdetails_cpu_ns gcdetails
-      , gcStatsGcWallSeconds          = nsToSecs $ gcdetails_elapsed_ns gcdetails
+      , gcStatsGcCpuSeconds           = nsToSecs $ gc_cpu_ns stats
+      , gcStatsGcWallSeconds          = nsToSecs $ gc_elapsed_ns stats
       , gcStatsCpuSeconds             = nsToSecs $ cpu_ns stats
       , gcStatsWallSeconds            = nsToSecs $ elapsed_ns stats
       }


### PR DESCRIPTION
Allocated bytes and copied bytes were incorrect because they were being used from the most recent gc rather than the accumulated values. I have corrected those.

The GC timing stats (`mutator_cpu_ns` and  `mutator_elapsed_ns `) are still not correct because they are not monotonic and sometimes decrease quite a bit making the interval measurement negative. I have opened a GHC ticket for that - http://ghc.haskell.org/trac/ghc/ticket/14445.