### PR TITLE
Documentation update, user exposed interface cleanup

### DIFF
--- a/Gauge.hs
+++ b/Gauge.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP             #-}
-{-# LANGUAGE RecordWildCards #-}
 -- |
 -- Module      : Gauge
 -- Copyright   : (c) 2009-2014 Bryan O'Sullivan
@@ -9,38 +8,14 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
--- Core benchmarking code.
+-- Fast and reliable micro benchmarking.
 
 module Gauge
-    (
-    -- * Benchmarkable code
-      Benchmarkable
-    -- * Creating a benchmark suite
-    , Benchmark
-    , env
-    , envWithCleanup
-    , perBatchEnv
-    , perBatchEnvWithCleanup
-    , perRunEnv
-    , perRunEnvWithCleanup
-    , toBenchmarkable
-    , bench
-    , bgroup
-    -- ** Running a benchmark
-    , nf
-    , whnf
-    , nfIO
-    , whnfIO
-    -- * For interactive use
-    , benchmark
-    , benchmarkWith
-#ifdef HAVE_ANALYSIS
-    , benchmark'
-    , benchmarkWith'
-#endif
+    ( module Gauge.Benchmark
+    , module Gauge.Main
+    , module Gauge.Main.Options
     ) where
 
-#ifdef HAVE_ANALYSIS
-import Gauge.Analysis (benchmark', benchmarkWith')
-#endif
 import Gauge.Benchmark
+import Gauge.Main
+import Gauge.Main.Options

--- a/Gauge/Analysis.hs
+++ b/Gauge/Analysis.hs
@@ -43,13 +43,13 @@ import Data.Monoid
 import Control.Arrow (second)
 import Control.DeepSeq (NFData(rnf))
 import Control.Monad (forM_, when)
-import Gauge.Benchmark (Benchmarkable, runWithAnalysisInteractive)
+import Gauge.Benchmark (Benchmark (..), Benchmarkable, runBenchmarkWith)
 import Gauge.IO.Printf (note, printError, prolix, rewindClearLine)
 import Gauge.Main.Options (defaultConfig, Config(..), Verbosity (..),
                            DisplayMode (..))
 import Gauge.Measurement (Measured(measTime), secs, rescale, measureKeys,
                           measureAccessors_, validateAccessors, renderNames)
-import Gauge.Monad (Gauge, askConfig, gaugeIO, Crit(..), askCrit)
+import Gauge.Monad (Gauge, askConfig, gaugeIO, Crit(..), askCrit, withConfig)
 import Data.Data (Data, Typeable)
 import Data.Int (Int64)
 import Data.IORef (IORef, readIORef, writeIORef)
@@ -470,12 +470,18 @@ printOverallEffect Slight     = "slightly inflated"
 printOverallEffect Moderate   = "moderately inflated"
 printOverallEffect Severe     = "severely inflated"
 
--- | Run a benchmark interactively, analyse its performance, and
--- return the analysis.
-benchmark' :: Benchmarkable -> IO Report
-benchmark' = benchmarkWith' defaultConfig
+-- XXX The original type of these types returned 'Report' type. But the
+-- implementation was wrong as it was not running any environment settings on
+-- the way to the benchmark. Now, we have used the correct function to do that
+-- but unfortunately that function returns void. That can be fixed though if it
+-- is important.
 
--- | Run a benchmark interactively, analyse its performance, and
--- return the analysis.
-benchmarkWith' :: Config -> Benchmarkable -> IO Report
-benchmarkWith' = runWithAnalysisInteractive analyseBenchmark
+-- | Run a benchmark interactively and analyse its performance.
+benchmarkWith' :: Config -> Benchmarkable -> IO ()
+benchmarkWith' cfg bm =
+  withConfig cfg $
+    runBenchmarkWith analyseBenchmark (const True) (Benchmark "function" bm)
+
+-- | Run a benchmark interactively and analyse its performanc.
+benchmark' :: Benchmarkable -> IO ()
+benchmark' = benchmarkWith' defaultConfig

--- a/Gauge/Analysis.hs
+++ b/Gauge/Analysis.hs
@@ -43,7 +43,7 @@ import Data.Monoid
 import Control.Arrow (second)
 import Control.DeepSeq (NFData(rnf))
 import Control.Monad (forM_, when)
-import Gauge.Benchmark (Benchmark (..), Benchmarkable, runBenchmarkWith)
+import Gauge.Benchmark (Benchmark (..), Benchmarkable, runBenchmark)
 import Gauge.IO.Printf (note, printError, prolix, rewindClearLine)
 import Gauge.Main.Options (defaultConfig, Config(..), Verbosity (..),
                            DisplayMode (..))
@@ -480,7 +480,7 @@ printOverallEffect Severe     = "severely inflated"
 benchmarkWith' :: Config -> Benchmarkable -> IO ()
 benchmarkWith' cfg bm =
   withConfig cfg $
-    runBenchmarkWith analyseBenchmark (const True) (Benchmark "function" bm)
+    runBenchmark (const True) (Benchmark "function" bm) analyseBenchmark
 
 -- | Run a benchmark interactively and analyse its performanc.
 benchmark' :: Benchmarkable -> IO ()

--- a/Gauge/Benchmark.hs
+++ b/Gauge/Benchmark.hs
@@ -15,7 +15,7 @@
 
 module Gauge.Benchmark
     (
-    -- * How to write benchmarks
+    -- * Benchmarkable
     -- $bench
 
     -- ** Benchmarking IO actions
@@ -27,25 +27,35 @@ module Gauge.Benchmark
     -- ** Fully evaluating a result
     -- $rnf
 
-    -- * Benchmark descriptions
       Benchmarkable(..)
-    , Benchmark(..)
-    -- * Benchmark construction
-    , env
-    , envWithCleanup
-    , perBatchEnv
-    , perBatchEnvWithCleanup
-    , perRunEnv
-    , perRunEnvWithCleanup
+
+    -- ** Constructing Benchmarkable
     , toBenchmarkable
-    , bench
-    , bgroup
-    , benchNames
-    -- ** Evaluation control
     , whnf
     , nf
     , nfIO
     , whnfIO
+
+    -- ** Constructing Benchmarkable with Environment
+    , perBatchEnv
+    , perBatchEnvWithCleanup
+    , perRunEnv
+    , perRunEnvWithCleanup
+
+    -- * Benchmarks
+    , Benchmark(..)
+
+    -- ** Constructing Benchmarks
+    , bench
+    , bgroup
+
+    -- ** Constructing Benchmarks with Environment
+    , env
+    , envWithCleanup
+
+    -- * Listing benchmarks
+    , benchNames
+
     -- * Running Benchmarks
     , runBenchmark
     , runBenchmarkIters
@@ -69,10 +79,10 @@ import System.Process (callProcess)
 
 -- $bench
 --
--- The 'Benchmarkable' type is a container for code that can be
--- benchmarked.  The value inside must run a benchmark the given
--- number of times.  We are most interested in benchmarking two
--- things:
+-- The 'Benchmarkable' type is a container for code that can be benchmarked.
+-- 'Benchmarkable' is the leaf to construct a 'Benchmark'. The value inside
+-- must run a benchmark the given number of times.  We are most interested in
+-- benchmarking two things:
 --
 -- * 'IO' actions.  Any 'IO' action can be benchmarked directly.
 --
@@ -84,8 +94,8 @@ import System.Process (callProcess)
 
 -- $io
 --
--- Any 'IO' action can be benchmarked easily if its type resembles
--- this:
+-- Any 'IO' action can be benchmarked easily (e.g. using 'nfIO' or 'whnfIO') if
+-- its type resembles this:
 --
 -- @
 -- 'IO' a

--- a/Gauge/Benchmark.hs
+++ b/Gauge/Benchmark.hs
@@ -11,10 +11,22 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
--- Core benchmarking code.
+-- Constructing and running benchmarks.
 
 module Gauge.Benchmark
     (
+    -- * How to write benchmarks
+    -- $bench
+
+    -- ** Benchmarking IO actions
+    -- $io
+
+    -- ** Benchmarking pure code
+    -- $pure
+
+    -- ** Fully evaluating a result
+    -- $rnf
+
     -- * Benchmark descriptions
       Benchmarkable(..)
     , Benchmark(..)
@@ -28,7 +40,6 @@ module Gauge.Benchmark
     , toBenchmarkable
     , bench
     , bgroup
-    , addPrefix
     , benchNames
     -- ** Evaluation control
     , whnf
@@ -36,18 +47,8 @@ module Gauge.Benchmark
     , nfIO
     , whnfIO
     -- * Running Benchmarks
-    , runBenchmark
-    , runBenchmarkable
-    , runBenchmarkable_
-    , runQuick
-    , runWithAnalysis
-    , runWithAnalysisInteractive
-    , runOnly
+    , runBenchmarkWith
     , runFixedIters
-    , quickAnalyse
-    -- * Running Benchmarks Interactively
-    , benchmark
-    , benchmarkWith
     ) where
 
 import Control.Applicative ((<*))
@@ -56,16 +57,105 @@ import Control.Exception (bracket, catch, evaluate, finally)
 import Control.Monad (foldM, void, when)
 import Data.Int (Int64)
 import Data.List (unfoldr)
-import Gauge.IO.Printf (note, prolix, rewindClearLine)
-import Gauge.Main.Options (defaultConfig, Config(..), Verbosity(..))
-import Gauge.Measurement (initializeTime, measure, getTime, secs,
-                          measureAccessors_, rescale, Measured(..))
-import Gauge.Monad (Gauge, finallyGauge, askConfig, gaugeIO, withConfig)
+import Gauge.IO.Printf (note, prolix)
+import Gauge.Main.Options (Config(..))
+import Gauge.Measurement (measure, getTime, secs, Measured(..))
+import Gauge.Monad (Gauge, finallyGauge, askConfig, gaugeIO)
 import System.Directory (canonicalizePath, getTemporaryDirectory, removeFile)
-import System.IO (hClose, hSetBuffering, BufferMode(..), openTempFile, stdout)
+import System.IO (hClose, openTempFile)
 import System.Mem (performGC)
 import qualified Data.Vector as V
 import System.Process (callProcess)
+
+-- $bench
+--
+-- The 'Benchmarkable' type is a container for code that can be
+-- benchmarked.  The value inside must run a benchmark the given
+-- number of times.  We are most interested in benchmarking two
+-- things:
+--
+-- * 'IO' actions.  Any 'IO' action can be benchmarked directly.
+--
+-- * Pure functions.  GHC optimises aggressively when compiling with
+--   @-O@, so it is easy to write innocent-looking benchmark code that
+--   doesn't measure the performance of a pure function at all.  We
+--   work around this by benchmarking both a function and its final
+--   argument together.
+
+-- $io
+--
+-- Any 'IO' action can be benchmarked easily if its type resembles
+-- this:
+--
+-- @
+-- 'IO' a
+-- @
+
+-- $pure
+--
+-- Because GHC optimises aggressively when compiling with @-O@, it is
+-- potentially easy to write innocent-looking benchmark code that will
+-- only be evaluated once, for which all but the first iteration of
+-- the timing loop will be timing the cost of doing nothing.
+--
+-- To work around this, we provide two functions for benchmarking pure
+-- code.
+--
+-- The first will cause results to be fully evaluated to normal form
+-- (NF):
+--
+-- @
+-- 'nf' :: 'NFData' b => (a -> b) -> a -> 'Benchmarkable'
+-- @
+--
+-- The second will cause results to be evaluated to weak head normal
+-- form (the Haskell default):
+--
+-- @
+-- 'whnf' :: (a -> b) -> a -> 'Benchmarkable'
+-- @
+--
+-- As both of these types suggest, when you want to benchmark a
+-- function, you must supply two values:
+--
+-- * The first element is the function, saturated with all but its
+--   last argument.
+--
+-- * The second element is the last argument to the function.
+--
+-- Here is an example that makes the use of these functions clearer.
+-- Suppose we want to benchmark the following function:
+--
+-- @
+-- firstN :: Int -> [Int]
+-- firstN k = take k [(0::Int)..]
+-- @
+--
+-- So in the easy case, we construct a benchmark as follows:
+--
+-- @
+-- 'nf' firstN 1000
+-- @
+
+-- $rnf
+--
+-- The 'whnf' harness for evaluating a pure function only evaluates
+-- the result to weak head normal form (WHNF).  If you need the result
+-- evaluated all the way to normal form, use the 'nf' function to
+-- force its complete evaluation.
+--
+-- Using the @firstN@ example from earlier, to naive eyes it might
+-- /appear/ that the following code ought to benchmark the production
+-- of the first 1000 list elements:
+--
+-- @
+-- 'whnf' firstN 1000
+-- @
+--
+-- Since we are using 'whnf', in this case the result will only be
+-- forced until it reaches WHNF, so what this would /actually/
+-- benchmark is merely how long it takes to produce the first list
+-- element!
 
 -- | A pure function or impure action that can be benchmarked. The
 -- 'Int64' parameter indicates the number of times to run the given
@@ -373,12 +463,12 @@ benchNames (BenchGroup d bs) = map (addPrefix d) . concatMap benchNames $ bs
 -- | Take a 'Benchmarkable', number of iterations, a function to combine the
 -- results of multiple iterations and a measurement function to measure the
 -- stats over a number of iterations.
-runBenchmarkable :: Benchmarkable
+iterateBenchmarkable :: Benchmarkable
                  -> Int64
                  -> (a -> a -> a)
                  -> (IO () -> IO a)
                  -> IO a
-runBenchmarkable Benchmarkable{..} i comb f
+iterateBenchmarkable Benchmarkable{..} i comb f
     | perRun = work >>= go (i - 1)
     | otherwise = work
   where
@@ -398,11 +488,11 @@ runBenchmarkable Benchmarkable{..} i comb f
         performGC
         f run `finally` clean <* performGC
     {-# INLINE work #-}
-{-# INLINE runBenchmarkable #-}
+{-# INLINE iterateBenchmarkable #-}
 
-runBenchmarkable_ :: Benchmarkable -> Int64 -> IO ()
-runBenchmarkable_ bm i = runBenchmarkable bm i (\() () -> ()) id
-{-# INLINE runBenchmarkable_ #-}
+iterateBenchmarkable_ :: Benchmarkable -> Int64 -> IO ()
+iterateBenchmarkable_ bm i = iterateBenchmarkable bm i (\() () -> ()) id
+{-# INLINE iterateBenchmarkable_ #-}
 
 series :: Double -> Maybe (Int64, Double)
 series k = Just (truncate l, l)
@@ -419,7 +509,7 @@ squish ys = foldr go [] ys
 -- benchmark will not terminate until we reach all the minimum bounds
 -- specified. If the minimum bounds are satisfied, the benchmark will terminate
 -- as soon as we reach any of the maximums.
-runBenchmark :: Benchmarkable
+runBenchmarkable' :: Benchmarkable
              -> Int
              -- ^ Minimum sample duration to in ms.
              -> Int
@@ -428,12 +518,12 @@ runBenchmark :: Benchmarkable
              -- ^ Upper bound on how long the benchmarking process
              -- should take.
              -> IO (V.Vector Measured, Double)
-runBenchmark bm minDuration minSamples timeLimit = do
-  runBenchmarkable_ bm 1
+runBenchmarkable' bm minDuration minSamples timeLimit = do
+  iterateBenchmarkable_ bm 1
   start <- performGC >> getTime
   let loop [] !_ _ = error "unpossible!"
       loop (iters:niters) samples acc = do
-        m <- measure (runBenchmarkable bm iters) iters
+        m <- measure (iterateBenchmarkable bm iters) iters
         endTime <- getTime
         if samples >= minSamples &&
            measTime m >= fromIntegral minDuration / 1000 &&
@@ -460,10 +550,10 @@ withSystemTempFile template action = do
     (action)
   ignoringIOErrors act = act `catch` (\e -> const (return ()) (e :: IOError))
 
--- | Run a single benchmark measurement only in a separate process.
-runBenchmarkWith :: String -> String -> Double -> Bool
-                 -> IO (V.Vector Measured, Double)
-runBenchmarkWith prog desc tlimit quick =
+-- | Run a single benchmark measurement in a separate process.
+runBenchmarkIsolated :: String -> String -> Double -> Bool
+                     -> IO (V.Vector Measured)
+runBenchmarkIsolated prog desc tlimit quick =
     withSystemTempFile "gauge-quarantine" $ \file -> do
       -- XXX This is dependent on option names, if the option names change this
       -- will break.
@@ -472,95 +562,33 @@ runBenchmarkWith prog desc tlimit quick =
                          ] ++ if quick then ["--quick"] else [])
       readFile file >>= return . read
 
--- | Run a single benchmark.
-runOne :: String -> Benchmarkable -> Maybe FilePath
-       -> Gauge (V.Vector Measured)
-runOne desc bm file = do
+-- | Run a single benchmarkable and return the result.
+runBenchmarkable :: String -> Benchmarkable
+  -> Gauge (V.Vector Measured)
+runBenchmarkable desc bm = do
   Config{..} <- askConfig
-  r@(meas, timeTaken) <-
-    case measureWith of
-      Just prog -> gaugeIO $ runBenchmarkWith prog desc timeLimit quickMode
-      Nothing -> gaugeIO $
+  case measureWith of
+    Just prog -> gaugeIO $ runBenchmarkIsolated prog desc timeLimit quickMode
+    Nothing -> gaugeIO $ do
+      _ <- note "benchmarking %s" desc
+      (meas, timeTaken) <-
         if quickMode
-        then runBenchmark bm 30 2 0
-        else runBenchmark bm 30 10 timeLimit
-  case file of
-    Just f -> gaugeIO $ writeFile f (show r)
-    Nothing ->
+        then runBenchmarkable' bm 30 2 0
+        else runBenchmarkable' bm 30 10 timeLimit
       when (timeTaken > timeLimit * 1.25) .
         void $ prolix "measurement took %s\n" (secs timeTaken)
-  return meas
+      return meas
 
-runOnly :: FilePath -> (String -> Bool) -> Benchmark -> Gauge ()
-runOnly outfile select bs =
-  for select bs $ \_ desc bm -> runOne desc bm (Just outfile) >> return ()
-
--- | Run a single benchmark and analyse its performance.
-runAndAnalyseOne
-  :: (String -> V.Vector Measured -> Gauge a)
-  -> String
-  -> Benchmarkable
-  -> Gauge a
-runAndAnalyseOne analyse desc bm = do
-  _ <- note "benchmarking %s" desc
-  runOne desc bm Nothing >>= analyse desc
-
-runWithAnalysis
-  :: (String -> V.Vector Measured -> Gauge a)
-  -> (String -> Bool)
-  -> Benchmark
+-- | Run all benchmarkables under a benchmark selected by a selector function
+-- using a given analysis function.
+runBenchmarkWith
+  :: (String -> V.Vector Measured -> Gauge a) -- ^ Analysis function
+  -> (String -> Bool) -- ^ Function to determine whether to run a benchmark
+  -> Benchmark        -- ^ Benchmark tree
   -> Gauge ()
-runWithAnalysis analyse select bs = do
-  gaugeIO $ hSetBuffering stdout NoBuffering
-  for select bs $ \_ desc bm -> do
-    _ <- runAndAnalyseOne analyse desc bm
-    return ()
-
--- | Run a benchmark interactively, analyse its performance, and
--- return the analysis.
-runWithAnalysisInteractive
-  :: (String -> V.Vector Measured -> Gauge a)
-  -> Config
-  -> Benchmarkable
-  -> IO a
-runWithAnalysisInteractive analyse cfg bm = do
-  initializeTime
-  withConfig cfg $ runAndAnalyseOne analyse "function" bm
-
--- | Analyse a single benchmark.
-quickAnalyse :: String -> V.Vector Measured -> Gauge ()
-quickAnalyse desc meas = do
-  Config{..} <- askConfig
-  let accessors =
-        if verbosity == Verbose
-        then filter (("iters" /=) . fst) measureAccessors_
-        else filter (("time" ==)  . fst) measureAccessors_
-
-  _ <- note "%s%-40s " rewindClearLine desc
-  if verbosity == Verbose then gaugeIO (putStrLn "") else return ()
-  _ <- traverse
-        (\(k, (a, s, _)) -> reportStat a s k)
-        accessors
-  _ <- note "\n"
-  pure ()
-
-  where
-
-  reportStat accessor sh msg =
-    when (not $ V.null meas) $
-      let val = (accessor . rescale) $ V.last meas
-       in maybe (return ()) (\x -> note "%-20s %-10s\n" msg (sh x)) val
-
-runQuick :: (String -> Bool) -> Benchmark -> Gauge ()
-runQuick = runWithAnalysis quickAnalyse
-
--- | Run a benchmark interactively, and analyse its performance.
-benchmark :: Benchmarkable -> IO ()
-benchmark = benchmarkWith defaultConfig
-
--- | Run a benchmark interactively, and analyse its performance.
-benchmarkWith :: Config -> Benchmarkable -> IO ()
-benchmarkWith = runWithAnalysisInteractive quickAnalyse
+runBenchmarkWith analyse selector bs =
+  for selector bs $ \_idx desc bm ->
+      runBenchmarkable desc bm >>= analyse desc >>= \_ -> return ()
 
 -- XXX For consistency, this should also use a separate process when
 -- --measure-with is specified.
@@ -574,7 +602,7 @@ runFixedIters :: Int64            -- ^ Number of loop iterations to run.
 runFixedIters iters select bs =
   for select bs $ \_idx desc bm -> do
     _ <- note "benchmarking %s\r" desc
-    gaugeIO $ runBenchmarkable_ bm iters
+    gaugeIO $ iterateBenchmarkable_ bm iters
 
 -- | Iterate over benchmarks.
 for :: (String -> Bool)

--- a/Gauge/Main.hs
+++ b/Gauge/Main.hs
@@ -16,61 +16,35 @@
 
 module Gauge.Main
     (
-    -- * How to write benchmarks
-    -- $bench
-
-    -- ** Benchmarking IO actions
-    -- $io
-
-    -- ** Benchmarking pure code
-    -- $pure
-
-    -- ** Fully evaluating a result
-    -- $rnf
-
-    -- * Types
-      Benchmarkable
-    , Benchmark
-    -- * Creating a benchmark suite
-    , env
-    , envWithCleanup
-    , perBatchEnv
-    , perBatchEnvWithCleanup
-    , perRunEnv
-    , perRunEnvWithCleanup
-    , toBenchmarkable
-    , bench
-    , bgroup
-    -- ** Running a benchmark
-    , nf
-    , whnf
-    , nfIO
-    , whnfIO
     -- * Turning a suite of benchmarks into a program
-    , defaultMain
+      defaultMain
     , defaultMainWith
+    , runMode
     , defaultConfig
+    -- * Running Benchmarks Interactively
+    , benchmark
+    , benchmarkWith
     -- * Other useful code
     , makeMatcher
-    , runMode
     ) where
 
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 #ifdef HAVE_ANALYSIS
 import Gauge.Analysis (analyseBenchmark)
-import Gauge.Benchmark (runWithAnalysis)
 #endif
-import Gauge.IO.Printf (printError)
+import Gauge.IO.Printf (note, printError, rewindClearLine)
 import Gauge.Benchmark
 import Gauge.Main.Options
-import Gauge.Measurement (initializeTime)
-import Gauge.Monad (withConfig, gaugeIO)
+import Gauge.Measurement (Measured, measureAccessors_, rescale)
+import Gauge.Monad (Gauge, askConfig, withConfig, gaugeIO)
 import Data.Char (toLower)
 import Data.List (isInfixOf, isPrefixOf, sort)
 import System.Environment (getProgName, getArgs)
 import System.Exit (ExitCode(..), exitWith)
 -- import System.FilePath.Glob
+import System.IO (BufferMode(..), hSetBuffering, stdout)
 import System.IO.CodePage (withCP65001)
+import qualified Data.Vector as V
 
 -- | An entry point that can be used as a @main@ function.
 --
@@ -90,6 +64,8 @@ import System.IO.CodePage (withCP65001)
 defaultMain :: [Benchmark] -> IO ()
 defaultMain = defaultMainWith defaultConfig
 
+-- XXX We do not need Either in the return type of this?
+
 -- | Create a function that can tell if a name given on the command
 -- line matches a benchmark.
 makeMatcher :: MatchType
@@ -102,12 +78,57 @@ makeMatcher matchKind args =
     Pattern -> Right $ \b -> null args || any (`isInfixOf` b) args
     IPattern -> Right $ \b -> null args || any (`isInfixOf` map toLower b) (map (map toLower) args)
 
+-- | Display an error message from a command line parsing failure, and
+-- exit.
+parseError :: String -> IO a
+parseError msg = do
+  _ <- printError "Error: %s\n" msg
+  _ <- printError "Run \"%s --help\" for usage information\n" =<< getProgName
+  exitWith (ExitFailure 64)
+
 selectBenches :: MatchType -> [String] -> Benchmark -> IO (String -> Bool)
 selectBenches matchType benches bsgroup = do
   toRun <- either parseError return . makeMatcher matchType $ benches
   unless (null benches || any toRun (benchNames bsgroup)) $
     parseError "none of the specified names matches a benchmark"
   return toRun
+
+-- | Analyse a single benchmark, printing just the time by default and all
+-- stats in verbose mode.
+quickAnalyse :: String -> V.Vector Measured -> Gauge ()
+quickAnalyse desc meas = do
+  Config{..} <- askConfig
+  let accessors =
+        if verbosity == Verbose
+        then filter (("iters" /=) . fst) measureAccessors_
+        else filter (("time" ==)  . fst) measureAccessors_
+
+  _ <- note "%s%-40s " rewindClearLine desc
+  if verbosity == Verbose then gaugeIO (putStrLn "") else return ()
+  _ <- traverse
+        (\(k, (a, s, _)) -> reportStat a s k)
+        accessors
+  _ <- note "\n"
+  pure ()
+
+  where
+
+  reportStat accessor sh msg =
+    when (not $ V.null meas) $
+      let val = (accessor . rescale) $ V.last meas
+       in maybe (return ()) (\x -> note "%-20s %-10s\n" msg (sh x)) val
+
+-- | Run a benchmark interactively with supplied config, and analyse its
+-- performance.
+benchmarkWith :: Config -> Benchmarkable -> IO ()
+benchmarkWith cfg bm =
+  withConfig cfg $
+    runBenchmarkWith quickAnalyse (const True) (Benchmark "function" bm)
+
+-- | Run a benchmark interactively with default config, and analyse its
+-- performance.
+benchmark :: Benchmarkable -> IO ()
+benchmark = benchmarkWith defaultConfig
 
 -- | An entry point that can be used as a @main@ function, with
 -- configurable defaults.
@@ -161,120 +182,22 @@ runMode wat cfg benches bs =
     Help    -> putStrLn describe
     DefaultMode ->
       case measureOnly cfg of
-        Just outfile -> runWithConfig $ runOnly outfile
+        Just outfile -> runWithConfig $ runBenchmarkWith (\_ r ->
+                          gaugeIO (writeFile outfile (show r)))
         Nothing ->
           case iters cfg of
           Just nbIters -> runWithConfig $ runFixedIters nbIters
           Nothing ->
             case quickMode cfg of
-              True  -> runWithConfig runQuick
+              True  -> runWithConfig (runBenchmarkWith quickAnalyse)
               False ->
 #ifdef HAVE_ANALYSIS
-                  runWithConfig (runWithAnalysis analyseBenchmark)
+                  runWithConfig (runBenchmarkWith analyseBenchmark)
 #else
-                  runWithConfig runQuick
+                  runWithConfig (runBenchmarkWith quickAnalyse)
 #endif
   where bsgroup = BenchGroup "" bs
         runWithConfig f = do
-          shouldRun <- selectBenches (match cfg) benches bsgroup
-          withConfig cfg $ do
-            gaugeIO initializeTime
-            f shouldRun bsgroup
-
--- | Display an error message from a command line parsing failure, and
--- exit.
-parseError :: String -> IO a
-parseError msg = do
-  _ <- printError "Error: %s\n" msg
-  _ <- printError "Run \"%s --help\" for usage information\n" =<< getProgName
-  exitWith (ExitFailure 64)
-
--- $bench
---
--- The 'Benchmarkable' type is a container for code that can be
--- benchmarked.  The value inside must run a benchmark the given
--- number of times.  We are most interested in benchmarking two
--- things:
---
--- * 'IO' actions.  Any 'IO' action can be benchmarked directly.
---
--- * Pure functions.  GHC optimises aggressively when compiling with
---   @-O@, so it is easy to write innocent-looking benchmark code that
---   doesn't measure the performance of a pure function at all.  We
---   work around this by benchmarking both a function and its final
---   argument together.
-
--- $io
---
--- Any 'IO' action can be benchmarked easily if its type resembles
--- this:
---
--- @
--- 'IO' a
--- @
-
--- $pure
---
--- Because GHC optimises aggressively when compiling with @-O@, it is
--- potentially easy to write innocent-looking benchmark code that will
--- only be evaluated once, for which all but the first iteration of
--- the timing loop will be timing the cost of doing nothing.
---
--- To work around this, we provide two functions for benchmarking pure
--- code.
---
--- The first will cause results to be fully evaluated to normal form
--- (NF):
---
--- @
--- 'nf' :: 'NFData' b => (a -> b) -> a -> 'Benchmarkable'
--- @
---
--- The second will cause results to be evaluated to weak head normal
--- form (the Haskell default):
---
--- @
--- 'whnf' :: (a -> b) -> a -> 'Benchmarkable'
--- @
---
--- As both of these types suggest, when you want to benchmark a
--- function, you must supply two values:
---
--- * The first element is the function, saturated with all but its
---   last argument.
---
--- * The second element is the last argument to the function.
---
--- Here is an example that makes the use of these functions clearer.
--- Suppose we want to benchmark the following function:
---
--- @
--- firstN :: Int -> [Int]
--- firstN k = take k [(0::Int)..]
--- @
---
--- So in the easy case, we construct a benchmark as follows:
---
--- @
--- 'nf' firstN 1000
--- @
-
--- $rnf
---
--- The 'whnf' harness for evaluating a pure function only evaluates
--- the result to weak head normal form (WHNF).  If you need the result
--- evaluated all the way to normal form, use the 'nf' function to
--- force its complete evaluation.
---
--- Using the @firstN@ example from earlier, to naive eyes it might
--- /appear/ that the following code ought to benchmark the production
--- of the first 1000 list elements:
---
--- @
--- 'whnf' firstN 1000
--- @
---
--- Since we are using 'whnf', in this case the result will only be
--- forced until it reaches WHNF, so what this would /actually/
--- benchmark is merely how long it takes to produce the first list
--- element!
+          hSetBuffering stdout NoBuffering
+          selector <- selectBenches (match cfg) benches bsgroup
+          withConfig cfg $ f selector bsgroup

--- a/Gauge/Main.hs
+++ b/Gauge/Main.hs
@@ -70,7 +70,7 @@ parseError msg = do
 
 selectBenches :: MatchType -> [String] -> Benchmark -> IO (String -> Bool)
 selectBenches matchType benches bsgroup = do
-  let toRun = makeMatcher matchType benches
+  let toRun = makeSelector matchType benches
   unless (null benches || any toRun (benchNames bsgroup)) $
     parseError "none of the specified names matches a benchmark"
   return toRun

--- a/Gauge/Main/Options.hs
+++ b/Gauge/Main/Options.hs
@@ -13,7 +13,7 @@
 
 module Gauge.Main.Options
     ( defaultConfig
-    , makeMatcher
+    , makeSelector
     , parseWith
     , describe
     , versionInfo
@@ -147,13 +147,13 @@ defaultConfig = Config
     , displayMode  = StatsTable
     }
 
--- | Create a function that can tell if a name given on the command
--- line matches a benchmark.
-makeMatcher :: MatchType
+-- | Create a benchmark selector function that can tell if a name given on the
+-- command line matches a defined benchmark.
+makeSelector :: MatchType
             -> [String]
             -- ^ Command line arguments.
             -> (String -> Bool)
-makeMatcher matchKind args =
+makeSelector matchKind args =
   case matchKind of
     Prefix   -> \b -> null args || any (`isPrefixOf` b) args
     Pattern  -> \b -> null args || any (`isInfixOf` b) args

--- a/Gauge/Main/Options.hs
+++ b/Gauge/Main/Options.hs
@@ -13,6 +13,7 @@
 
 module Gauge.Main.Options
     ( defaultConfig
+    , makeMatcher
     , parseWith
     , describe
     , versionInfo
@@ -34,6 +35,7 @@ import System.Console.GetOpt
 import Paths_gauge (version)
 import Data.Data (Data, Typeable)
 import Data.Int (Int64)
+import Data.List (isInfixOf, isPrefixOf)
 import GHC.Generics (Generic)
 
 -- | Control the amount of information displayed.
@@ -144,6 +146,18 @@ defaultConfig = Config
     , mode         = DefaultMode
     , displayMode  = StatsTable
     }
+
+-- | Create a function that can tell if a name given on the command
+-- line matches a benchmark.
+makeMatcher :: MatchType
+            -> [String]
+            -- ^ Command line arguments.
+            -> (String -> Bool)
+makeMatcher matchKind args =
+  case matchKind of
+    Prefix   -> \b -> null args || any (`isPrefixOf` b) args
+    Pattern  -> \b -> null args || any (`isInfixOf` b) args
+    IPattern -> \b -> null args || any (`isInfixOf` map toLower b) (map (map toLower) args)
 
 parseWith :: Config
             -- ^ Default configuration to use

--- a/Gauge/Monad.hs
+++ b/Gauge/Monad.hs
@@ -25,6 +25,7 @@ import Control.Exception
 import Control.Monad (ap)
 import Data.IORef (IORef, newIORef)
 import Gauge.Main.Options (Config)
+import Gauge.Measurement (initializeTime)
 import System.Random.MWC (GenIO)
 
 data Crit = Crit
@@ -60,5 +61,6 @@ finallyGauge f g = Gauge $ \crit -> do
 -- | Run a 'Gauge' action with the given 'Config'.
 withConfig :: Config -> Gauge a -> IO a
 withConfig cfg act = do
+  initializeTime
   g <- newIORef Nothing
   runGauge act (Crit cfg g)

--- a/Gauge/Monad.hs
+++ b/Gauge/Monad.hs
@@ -33,7 +33,8 @@ data Crit = Crit
     , gen      :: !(IORef (Maybe GenIO))
     }
 
--- | The monad in which most gauge code executes.
+-- | 'Gauge' is essentially a reader monad to make the benchmark configuration
+-- available throughout the code.
 newtype Gauge a = Gauge { runGauge :: Crit -> IO a }
 
 instance Functor Gauge where
@@ -45,12 +46,14 @@ instance Monad Gauge where
     return    = pure
     ma >>= mb = Gauge $ \r -> runGauge ma r >>= \a -> runGauge (mb a) r
 
+-- | Retrieve the configuration from the 'Gauge' monad.
 askConfig :: Gauge Config
 askConfig = Gauge (pure . config)
 
 askCrit :: Gauge Crit
 askCrit = Gauge pure
 
+-- | Lift an IO action into the 'Gauge' monad.
 gaugeIO :: IO a -> Gauge a
 gaugeIO = Gauge . const
 

--- a/benchs/Main.hs
+++ b/benchs/Main.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 module Main where
 
-import Gauge.Main
+import Gauge
 import System.IO.Unsafe
 import Control.Concurrent
 import Control.Exception

--- a/gauge.cabal
+++ b/gauge.cabal
@@ -37,9 +37,9 @@ library
     Gauge
     Gauge.Main
     Gauge.Main.Options
+    Gauge.Benchmark
   other-modules:
     Gauge.IO.Printf
-    Gauge.Benchmark
     Gauge.Measurement
     Gauge.Monad
     Gauge.Time

--- a/tests/Cleanup.hs
+++ b/tests/Cleanup.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-import Gauge.Main (Benchmark, bench, nfIO)
+import Gauge.Benchmark(Benchmark, bench, nfIO)
 import Gauge.Main.Options (Config(..), Verbosity(Quiet))
 import Control.Applicative (pure)
 import Control.DeepSeq (NFData(..))
@@ -18,7 +18,7 @@ import System.IO ( Handle, IOMode(ReadWriteMode), SeekMode(AbsoluteSeek)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (testCase)
 import Test.HUnit (assertFailure)
-import qualified Gauge.Main as C
+import qualified Gauge as C
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 

--- a/tests/Sanity.hs
+++ b/tests/Sanity.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Gauge.Main (bench, bgroup, env, whnf)
+import Gauge.Benchmark (bench, bgroup, env, whnf)
 import System.Environment (getEnv, withArgs)
 import System.Timeout (timeout)
 import Test.Tasty (defaultMain)
 import Test.Tasty.HUnit (testCase)
 import Test.HUnit (Assertion, assertFailure)
-import qualified Gauge.Main as C
+import qualified Gauge as C
 import qualified Control.Exception as E
 import qualified Data.ByteString as B
 


### PR DESCRIPTION
See individual commit messages and haddock pages for more details.

This is mostly cosmetic changeset with no or minimal (see one of the commit messages) functionality change.

We still need the `Gauge` monad to be exposed (Gauge, askConfig etc.) for allowing the use of `runBenchmark` function by users, though I doubt if anyone will really need this function. To be consistent either we do not expose this function or expose the minimal types needed to use this.

It should be noted that the module structuring is not the same as Criterion and therefore existing criterion code (imports) may have to be massaged a bit to adapt. Just importing `Gauge` should bring everything a user needs (except `Gauge.Analysis` which nobody would ever need and we want to keep it separate, so I kept it out of Gauge). Though individual modules are also available for import.