### PR TITLE
Use the same script for appveyor and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,92 +1,92 @@
-# Use new container infrastructure to enable caching
-sudo: false
+notifications:
+  email: false
 
-# Caching so the next build will be fast too.
-cache:
-  directories:
-  - $HOME/.ghc
-  - $HOME/.cabal
-  - $HOME/.stack
+env:
+  global:
+  - GHC_OPTIONS="-O0 -Werror"
+  - PACKCHECK="./packcheck.sh"
+  # The commit id of packcheck.sh to use from harendra-kumar/packcheck on github
+  - PACKCHECK_COMMIT="6be708c5b34b5a2a7b553cf9ebe99f1f5764a79a"
 
-# The different configurations we want to test. We have BUILD=cabal which uses
-# cabal-install, and BUILD=stack which uses Stack.
 matrix:
   include:
-  - env: BUILD=hlint
-    language: generic
-    compiler: hlint
-  - env: BUILD=stack RESOLVER=ghc-8.0
-    language: generic
-    addons: { apt: { packages: [ libgmp-dev ] } }
-    compiler: ghc-8.0
-  - env: BUILD=stack RESOLVER=ghc-8.2
-    language: generic
-    compiler: ghc-8.2
-    addons: { apt: { packages: [ libgmp-dev ] } }
-  - env: BUILD=stack RESOLVER=ghc-8.2 STACK_OPTIONS="--flag gauge:-analysis"
-    language: generic
-    compiler: ghc-8.2
-    addons: { apt: { packages: [ libgmp-dev ] } }
-  - env: BUILD=stack RESOLVER=ghc-7.10
-    language: generic
-    addons: { apt: { packages: [ libgmp-dev ] } }
-    compiler: ghc-7.10
-  - env: BUILD=stack RESOLVER=ghc-7.8
-    language: generic
-    addons: { apt: { packages: [ libgmp-dev ] } }
-    compiler: ghc-7.8
-  - env: BUILD=stack RESOLVER=ghc-8.0
+
+  - env: BUILD=stack STACK_YAML=.travis/stack-ghc-7.8.yaml
+  - env: BUILD=stack STACK_YAML=.travis/stack-ghc-7.10.yaml
+  - env: BUILD=stack STACK_YAML=.travis/stack-ghc-8.0.yaml
+  - env: BUILD=stack STACK_YAML=.travis/stack-ghc-8.2.yaml
+  - env: BUILD=stack STACK_YAML=.travis/stack-ghc-8.2.yaml STACK_OPTIONS="--flag gauge:-analysis"
+  - env: BUILD=stack STACK_YAML=.travis/stack-ghc-8.2.yaml HLINT_OPTIONS=". --cpp-define=__GLASGOW_HASKELL__=800 --cpp-define=x86_64_HOST_ARCH=1 --cpp-define=mingw32_HOST_OS=1"
+  - env: BUILD=stack STACK_YAML=.travis/stack-ghc-8.2.yaml
     os: osx
-    language: generic
-    compiler: ghc-8.0
+
+  # Note COVERALLS (hpc-coveralls) works only with cabal build.
+  # For this to succeed you have to add your porject to coveralls.io first
+  #- env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 COVERALLS_OPTIONS="--coverage-mode=StrictlyFullLines --exclude-dir=test test"
+  #  addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
+
+  # --------------------------------------------------------------------------
+  # Builds that are allowed to fail
+  # --------------------------------------------------------------------------
 
   allow_failures:
-  - env: BUILD=hlint
-    language: generic
-    compiler: hlint
+  - env: BUILD=stack STACK_YAML=.travis/stack-ghc-8.2.yaml HLINT_OPTIONS=". --cpp-define=__GLASGOW_HASKELL__=800 --cpp-define=x86_64_HOST_ARCH=1 --cpp-define=mingw32_HOST_OS=1"
 
-install:
-  - export PATH=$HOME/.local/bin::$HOME/.cabal/bin:$PATH
-  - mkdir -p ~/.local/bin
-  - |
-    case "$BUILD" in
-      stack)
-        if [ `uname` = "Darwin" ]
-        then
-          travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
-        else
-          travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-        fi
-      ;;
-    cabal)
-      ;;
-    esac
+# ------------------------------------------------------------------------
+#  Settings beyond this point are advanced and normally not tweaked
+# ------------------------------------------------------------------------
+
+sudo: false
+cache:
+  directories:
+  - $HOME/.cabal
+  - $HOME/.ghc
+  - $HOME/.local
+  - $HOME/.stack
 
 script:
-- |
-  set -ex
-  if [ "x${RUNTEST}" = "xfalse" ]; then exit 0; fi
-  case "$BUILD" in
-    stack)
-      rm stack.yaml && ln -sv .travis/stack-${RESOLVER}.yaml stack.yaml
-      stack --no-terminal test $STACK_OPTIONS \
-          --install-ghc \
-          --coverage --bench --no-run-benchmarks \
-          --haddock --no-haddock-deps
-      ;;
-    cabal)
-      cabal install --only-dependencies --enable-tests
-      cabal test
-      cabal check
-      cabal sdist
-      ;;
-    hlint)
-      curl -sL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s . --cpp-define=__GLASGOW_HASKELL__=800 --cpp-define=x86_64_HOST_ARCH=1 --cpp-define=mingw32_HOST_OS=1
-      ;;
-  esac
-  set +ex
+  - |
+    # Where to find the packcheck.sh script
+    PACKCHECK_URL=https://raw.githubusercontent.com/harendra-kumar/packcheck/${PACKCHECK_COMMIT}/packcheck.sh
 
-# It doesn't seem to be working so far.
-#
-#after_script:
-#    - travis_retry curl -L https://github.com/rubik/stack-hpc-coveralls/releases/download/v0.0.3.0/shc-linux-x64-$GHCVER.tar.bz2 | tar -xj
+    # When GHCVER or CABALVER env variables are specified, modify the path to
+    # find the binaries installed from hvr-ghc repo
+    add_path()  { eval "test -n \"\$$1\"" && eval "PATH=/opt/$2/\"\$$1\"/bin:$PATH"; true; }
+
+    # Emit the value of the var specified as arg only when the build is cabal
+    cabal_env() { test "$BUILD" = cabal && echo $1; }
+
+    CURL=$(which curl)
+    PATH=/bin:/usr/bin
+    add_path GHCVER   ghc
+    add_path CABALVER cabal
+
+    # If a custom stack-yaml is specified, replace the default with that
+    if test -e "$STACK_YAML"; then rm -f stack.yaml && ln -sv $STACK_YAML stack.yaml; else true; fi
+    if test ! -e "$PACKCHECK"; then $CURL -sL -o "$PACKCHECK" $PACKCHECK_URL; fi;
+    chmod +x $PACKCHECK
+
+    # We start with a clean environment (env -i) and specify all the
+    # environment variables explicitly. TRAVIS vars are needed by
+    # hpc-coveralls.
+  - env -i
+      LC_ALL=C.UTF-8
+      TRAVIS=$TRAVIS
+      TRAVIS_JOB_ID=$TRAVIS_JOB_ID
+      PATH="$PATH"
+      RESOLVER=$RESOLVER
+      STACK_BUILD_OPTIONS="$STACK_BUILD_OPTIONS"
+      GHCVER=$GHCVER
+      GHC_OPTIONS="$GHC_OPTIONS"
+      COVERALLS_OPTIONS="$COVERALLS_OPTIONS"
+      CABAL_REINIT_CONFIG=y
+      TEST_INSTALL=y
+      $(cabal_env CABALVER=$CABALVER)
+      $(cabal_env CABAL_CHECK_RELAX=y)
+      $(cabal_env CABAL_NO_SANDBOX=y)
+      $(cabal_env CABAL_HACKAGE_MIRROR=hackage.haskell.org:http://hackage.fpcomplete.com)
+      HLINT_OPTIONS="$HLINT_OPTIONS"
+      bash -c "$PACKCHECK $BUILD"
+
+install: true
+language: c

--- a/.travis/stack-ghc-8.0.yaml
+++ b/.travis/stack-ghc-8.0.yaml
@@ -1,6 +1,3 @@
-resolver: lts-9.5
+resolver: lts-9.20
 packages:
 - '.'
-extra-deps: []
-flags: {}
-extra-package-dbs: []

--- a/.travis/stack-ghc-8.2.yaml
+++ b/.travis/stack-ghc-8.2.yaml
@@ -1,6 +1,3 @@
-resolver: nightly-2017-07-31
+resolver: lts-10.0
 packages:
 - '.'
-extra-deps:
-- basement-0.0.2
-- foundation-0.0.15

--- a/Gauge/Analysis.hs
+++ b/Gauge/Analysis.hs
@@ -56,7 +56,7 @@ import Data.Int (Int64)
 import Data.IORef (IORef, readIORef, writeIORef)
 import Gauge.ListMap (Map)
 import Data.Maybe (fromJust, isJust)
-import Data.Traversable (traverse)
+import Data.Traversable
 import GHC.Generics (Generic)
 import Statistics.Function (sort)
 import Statistics.Quantile (weightedAvg, Sorted(..))
@@ -75,7 +75,7 @@ import qualified Data.Vector.Unboxed as U
 import qualified Statistics.Resampling.Bootstrap as B
 import qualified Statistics.Types                as B
 import qualified Statistics.Types as St
-import Prelude
+import Prelude hiding (sequence, mapM)
 
 -- | Outliers from sample data, calculated using the boxplot
 -- technique.

--- a/Gauge/Benchmark.hs
+++ b/Gauge/Benchmark.hs
@@ -62,7 +62,7 @@ module Gauge.Benchmark
     , runBenchmarkIters
     ) where
 
-import Control.Applicative ((<*))
+import Control.Applicative
 import Control.DeepSeq (NFData(rnf))
 import Control.Exception (bracket, catch, evaluate, finally)
 import Control.Monad (foldM, void, when)
@@ -78,6 +78,7 @@ import System.IO (hClose, openTempFile)
 import System.Mem (performGC)
 import qualified Data.Vector as V
 import System.Process (callProcess)
+import Prelude
 
 -- $rnf
 --

--- a/Gauge/Source/GC.hs
+++ b/Gauge/Source/GC.hs
@@ -20,7 +20,7 @@ import           Gauge.Time
 import           System.IO.Unsafe (unsafePerformIO)
 
 #if MIN_VERSION_base(4,10,0)
-import qualified GHC.Stats as GHC (RTSStats(..), GCDetails(..), getRTSStatsEnabled, getRTSStats)
+import qualified GHC.Stats as GHC (RTSStats(..), getRTSStatsEnabled, getRTSStats)
 #else
 import qualified Control.Exception as Exn
 import qualified GHC.Stats as GHC (GCStats(..), getGCStats)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,38 +1,39 @@
-# short paths == fewer problems
-
-# criterion does not support 32-bit on Windows
 platform: x64
-
-clone_folder: "c:\\pkg"
 environment:
   global:
-    BUILD: "stack"
-    RESOLVER: "lts-9.12"
+    RESOLVER: "lts-10.0"
     GHC_OPTIONS: "-O0 -Werror"
-#   STACK_OPTIONS: "-v"
+    PACKCHECK: ./packcheck.sh
+    # The commit id of packcheck.sh to use from harendra-kumar/packcheck on github
+    PACKCHECK_COMMIT: "6be708c5b34b5a2a7b553cf9ebe99f1f5764a79a"
+
+    # ------------------------------------------------------------------------
+    # Normally you do not need to customize hereafter
+    # ------------------------------------------------------------------------
 
     STACK_ROOT: "c:\\sr"
     LOCAL_BIN: "%APPDATA%\\local\\bin"
     PATH: "%PATH%;%APPDATA%\\local\\bin"
     CABAL_REINIT_CONFIG: "y"
     TEST_INSTALL: "y"
-    PACKAGE_TEST_VER: "536355be0507c234e5b4ea51dafdb8c3d1ede948"
 
 cache:
-  - "%STACK_ROOT%" # stack root
-  # ghc & msys - cache restore takes almost same time as reinstall
-  # - "%LOCALAPPDATA%\\Programs\\stack"
+  - "%STACK_ROOT%"
   - "%LOCAL_BIN%"
   - "%APPDATA%\\cabal"
   - "%APPDATA%\\ghc"
+# - "%LOCALAPPDATA%\\Programs\\stack"
 
+clone_folder: "c:\\pkg"
 build: off
 
 before_test:
+- if not exist %PACKCHECK% curl -sSkL -o%PACKCHECK% https://raw.githubusercontent.com/harendra-kumar/packcheck/%PACKCHECK_COMMIT%/packcheck.sh
 - if not exist %LOCAL_BIN% mkdir %LOCAL_BIN%
 - where stack.exe || curl -sSkL -ostack.zip http://www.stackage.org/stack/windows-x86_64 && 7z x stack.zip stack.exe && move stack.exe %LOCAL_BIN%
-- curl -sSkL -opackage-test.sh https://raw.githubusercontent.com/harendra-kumar/package-test/%PACKAGE_TEST_VER%/package-test.sh
+- stack upgrade
+- stack --version
 
 test_script:
 - stack setup > nul
-- chcp 65001 && stack exec bash package-test.sh
+- chcp 65001 && stack exec bash -- -c "chmod +x %PACKCHECK%; %PACKCHECK% stack"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.10
+resolver: lts-10.0
 
 packages:
 - '.'

--- a/statistics/Statistics/Math/RootFinding.hs
+++ b/statistics/Statistics/Math/RootFinding.hs
@@ -20,11 +20,12 @@ module Statistics.Math.RootFinding
     -- $references
     ) where
 
-import Control.Applicative (Alternative(..), Applicative(..))
+import Control.Applicative
 import Control.Monad (MonadPlus(..), ap)
 import Data.Data (Data, Typeable)
 import GHC.Generics (Generic)
 import Numeric.MathFunctions.Comparison (within)
+import Prelude
 
 
 -- | The result of searching for a root of a mathematical function.

--- a/statistics/Statistics/Matrix/Algorithms.hs
+++ b/statistics/Statistics/Matrix/Algorithms.hs
@@ -10,13 +10,13 @@ module Statistics.Matrix.Algorithms
       qr
     ) where
 
-import Control.Applicative ((<$>), (<*>))
+import Control.Applicative
 import Control.Monad.ST (ST, runST)
-import Prelude hiding (sum, replicate)
 import Statistics.Matrix (Matrix, column, dimension, for, norm)
 import qualified Statistics.Matrix.Mutable as M
 import Statistics.Sample.Internal (sum)
 import qualified Data.Vector.Unboxed as U
+import Prelude hiding (sum, replicate)
 
 -- | /O(r*c)/ Compute the QR decomposition of a matrix.
 -- The result returned is the matrices (/q/,/r/).

--- a/statistics/Statistics/Matrix/Mutable.hs
+++ b/statistics/Statistics/Matrix/Mutable.hs
@@ -18,7 +18,7 @@ module Statistics.Matrix.Mutable
     , immutably
     ) where
 
-import Control.Applicative ((<$>))
+import Control.Applicative
 import Control.DeepSeq (NFData(..))
 import Control.Monad.ST (ST)
 import Statistics.Matrix.Types (Matrix(..), MMatrix(..), MVector)

--- a/statistics/Statistics/Regression.hs
+++ b/statistics/Statistics/Regression.hs
@@ -11,13 +11,12 @@ module Statistics.Regression
     , bootstrapRegress
     ) where
 
-import Control.Applicative ((<$>))
+import Control.Applicative
 import Control.Concurrent (forkIO)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
 import Control.DeepSeq (rnf)
 import Control.Monad (forM_, replicateM)
 import GHC.Conc (getNumCapabilities)
-import Prelude hiding (pred, sum)
 import Statistics.Function as F
 import Statistics.Matrix
 import Statistics.Matrix.Algorithms (qr)
@@ -30,6 +29,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Unboxed.Mutable as M
+import Prelude hiding (pred, sum)
 
 -- | Perform an ordinary least-squares regression on a set of
 -- predictors, and calculate the goodness-of-fit of the regression.

--- a/tests/Cleanup.hs
+++ b/tests/Cleanup.hs
@@ -6,7 +6,7 @@
 
 import Gauge.Benchmark(Benchmark, bench, nfIO)
 import Gauge.Main.Options (Config(..), Verbosity(Quiet))
-import Control.Applicative (pure)
+import Control.Applicative
 import Control.DeepSeq (NFData(..))
 import Control.Exception (Exception, try, throwIO)
 import Control.Monad (when)
@@ -21,6 +21,7 @@ import Test.HUnit (assertFailure)
 import qualified Gauge as C
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import Prelude
 
 instance NFData Handle where
     rnf !_ = ()


### PR DESCRIPTION
The appveyor test is based on https://github.com/harendra-kumar/package-test. I have adapted the travis tests as well to use the same script. This script creates a sdist first and tests the package after unpacking it from sdist. So we are sure that the package is ok to upload to hackage.

This script also has support for "cabal" tests using stack or pure cabal in case we want to build those as well. It also supports sending coverage info to coveralls.io for coverage reporting and badge. We can enable that if required.

Also changed the nightly resolver to lts-10.0 and lts-9 to lts-9.20.