### PR TITLE
Csv analysis dump

### DIFF
--- a/Gauge/CSV.hs
+++ b/Gauge/CSV.hs
@@ -1,0 +1,79 @@
+-- |
+-- Module      : Gauge.CSV
+-- Copyright   : (c) 2017 Vincent Hanquez
+--
+-- a very simple CSV printer
+-- 
+-- import qualified for best result
+--
+module Gauge.CSV
+    ( Row(..)
+    , outputRow
+    , Field
+    , float
+    , integral
+    , string
+    , write
+    ) where
+
+import Data.List (intercalate)
+
+-- | a CSV Field (numerical or string)
+--
+-- The content inside is properly escaped
+newtype Field = Field { unField :: String }
+    deriving (Show,Eq)
+
+-- | A Row of fields
+newtype Row = Row [Field]
+    deriving (Show,Eq)
+
+-- | Create a field from Double
+float :: Double -> Field
+float d = Field $ show d
+
+-- | Create a field for numerical integral
+integral :: Integral a => a -> Field
+integral i = Field $ show (toInteger i)
+
+-- | Create a field from String
+string :: String -> Field
+string s =
+    -- potentially a random string need to be escape,
+    -- first find out how it need to escaped, then
+    -- escape the data properly.
+    case needEscape NoEscape s of
+        NoEscape       -> Field s
+        Escape         -> Field ('"' : (s ++ "\""))
+        EscapeDoubling -> Field ('"' : doubleQuotes s)
+  where
+    needEscape EscapeDoubling _      = EscapeDoubling
+    needEscape e              []     = e
+    needEscape e              (x:xs)
+        | x == '"'                   = EscapeDoubling
+        | x `elem` toEscape          = needEscape (max e Escape) xs
+        | otherwise                  = needEscape e              xs
+
+    toEscape = ",\r\n"
+
+    doubleQuotes [] = ['"']
+    doubleQuotes (x:xs)
+        | x == '"'  = '"':'"':doubleQuotes xs
+        | otherwise = x : doubleQuotes xs
+
+-- | Output a row to a String
+outputRow :: Row -> String
+outputRow (Row fields) = intercalate "," $ map unField fields
+
+-- | 3 Possible modes of escaping:
+-- * none
+-- * normal quotes escapes
+-- * content need doubling because of double quote in content
+data Escaping = NoEscape | Escape | EscapeDoubling
+    deriving (Show,Eq,Ord)
+
+write :: Maybe FilePath
+      -> Row
+      -> IO ()
+write Nothing _   = return ()
+write (Just fp) r = appendFile fp (outputRow r ++ "\r\n")

--- a/Gauge/Main.hs
+++ b/Gauge/Main.hs
@@ -29,6 +29,7 @@ import Control.Applicative
 import Control.Monad (unless, when)
 #ifdef HAVE_ANALYSIS
 import Gauge.Analysis (analyseBenchmark)
+import qualified Gauge.CSV as CSV
 #endif
 import Gauge.IO.Printf (note, printError, rewindClearLine)
 import Gauge.Benchmark
@@ -176,8 +177,10 @@ runMode wat cfg benches bs =
           Nothing ->
             case quickMode cfg of
               True  -> runWithConfig runBenchmark quickAnalyse
-              False ->
+              False -> do
 #ifdef HAVE_ANALYSIS
+                  CSV.write (csvFile cfg) $ CSV.Row $ map CSV.string
+                        ["Name", "Mean","MeanLB","MeanUB","Stddev","StddevLB","StddevUB"]
                   runWithConfig runBenchmark analyseBenchmark
 #else
                   runWithConfig runBenchmark quickAnalyse

--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,6 @@ for outputing to terminal benchmark data.
 
 missing:
 
-* CSV export
 * JSON export
 * HTML/javascript pages
 * Glob benchmark matching

--- a/gauge.cabal
+++ b/gauge.cabal
@@ -44,6 +44,7 @@ library
     Gauge.Monad
     Gauge.ListMap
     Gauge.Time
+    Gauge.CSV
 
     Gauge.Source.RUsage
     Gauge.Source.GC


### PR DESCRIPTION
Re-add way to dump CSV analysis data with the --csv=option, which work and be compatible with criterion format.

This is related to #4 but doesn't solve #4 yet (adding a csv printer)