### PR TITLE
Optional value cleanup and better type level representation

### DIFF
--- a/Gauge/Optional.hs
+++ b/Gauge/Optional.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+-- |
+-- Module      : Gauge.Optional
+-- Copyright   : (c) 2017-2018 Vincent Hanquez
+--
+-- A sum-type free Maybe where the value Nothing is
+-- represented by a special value in the original
+-- domain supported
+--
+-- The OptionalTag class is where the special value
+-- is defined
+--
+{-# LANGUAGE DeriveGeneric #-}
+module Gauge.Optional
+    ( Optional
+    , toOptional
+    , unOptional
+    , OptionalTag(..)
+    , isOmitted
+    , omitted
+    , toMaybe
+    , fromMaybe
+    , map
+    , both
+    ) where
+
+import Prelude hiding (map)
+import Data.Int
+import Data.Word
+import Data.Data
+import GHC.Generics
+
+-- | A type representing a sum-type free Maybe a
+-- where a specific tag represent Nothing
+newtype Optional a = Optional { unOptional :: a }
+    deriving (Eq, Show, Read, Typeable, Data, Generic)
+
+class OptionalTag a where
+    optionalTag :: a
+    isOptionalTag :: a -> Bool
+
+instance OptionalTag Int64 where
+    optionalTag = minBound
+    isOptionalTag = (==) optionalTag
+instance OptionalTag Word64 where
+    optionalTag = maxBound
+    isOptionalTag = (==) optionalTag
+instance OptionalTag Double where
+    optionalTag = -1/0
+    isOptionalTag d = isInfinite d || isNaN d
+
+-- | Create an optional value from a 
+toOptional :: OptionalTag a => a -> Optional a
+toOptional v
+    | isOptionalTag v = error "Creating an optional valid value using the optional tag"
+    | otherwise       = Optional v
+{-# INLINE toOptional #-}
+
+omitted :: OptionalTag a => Optional a
+omitted = Optional optionalTag
+{-# INLINE omitted #-}
+
+isOmitted :: OptionalTag a => Optional a -> Bool
+isOmitted (Optional v)
+    | isOptionalTag v = True
+    | otherwise       = False
+    
+toMaybe :: OptionalTag a => Optional a -> Maybe a
+toMaybe (Optional v) | isOptionalTag v = Nothing
+                     | otherwise       = Just v
+{-# INLINE toMaybe #-}
+
+fromMaybe :: OptionalTag a => Maybe a -> Optional a
+fromMaybe Nothing  = Optional optionalTag
+fromMaybe (Just v)
+    | isOptionalTag v = error "fromMaybe: creating an optional value using the optional tag"
+    | otherwise       = Optional v
+{-# INLINE fromMaybe #-}
+
+map :: OptionalTag a => (a -> a) -> Optional a -> Optional a
+map f o@(Optional v) | isOptionalTag v = o
+                     | otherwise       = Optional (f v) 
+{-# INLINE map #-}
+
+both :: OptionalTag a => (a -> a -> a) -> Optional a -> Optional a -> Optional a
+both f o1 o2
+    | isOmitted o1    = o2
+    | isOmitted o2    = o1
+    | isOptionalTag r = error "both: creating an optional value using the optional tag"
+    | otherwise       = Optional r
+  where r = f (unOptional o1) (unOptional o2)

--- a/Gauge/Time.hs
+++ b/Gauge/Time.hs
@@ -20,22 +20,23 @@ import           Data.Data
 import           Data.Word
 import           Control.DeepSeq
 import           GHC.Generics
+import           Gauge.Optional (OptionalTag)
 
 -- | Represent a number of milliseconds.
 newtype MilliSeconds = MilliSeconds Word64
-    deriving (Eq, Read, Show, Typeable, Data, Generic, NFData, Enum, Bounded, Num)
+    deriving (Eq, Read, Show, Typeable, Data, Generic, NFData, Enum, Bounded, Num, OptionalTag)
 
 -- | Represent a number of microseconds
 newtype MicroSeconds = MicroSeconds Word64
-    deriving (Eq, Read, Show, Typeable, Data, Generic, NFData, Enum, Bounded, Num)
+    deriving (Eq, Read, Show, Typeable, Data, Generic, NFData, Enum, Bounded, Num, OptionalTag)
 
 -- | Represent a number of nanoseconds
 newtype NanoSeconds = NanoSeconds Word64
-    deriving (Eq, Read, Show, Typeable, Data, Generic, NFData, Enum, Bounded, Num)
+    deriving (Eq, Read, Show, Typeable, Data, Generic, NFData, Enum, Bounded, Num, OptionalTag)
 
 -- | Represent a number of hundreds of picoseconds
 newtype PicoSeconds100 = PicoSeconds100 Word64
-    deriving (Eq, Read, Show, Typeable, Data, Generic, NFData, Enum, Bounded, Num)
+    deriving (Eq, Read, Show, Typeable, Data, Generic, NFData, Enum, Bounded, Num, OptionalTag)
 
 ref_picoseconds100 :: Num a => a
 ref_picoseconds100 = 10000000000

--- a/gauge.cabal
+++ b/gauge.cabal
@@ -44,6 +44,7 @@ library
     Gauge.Monad
     Gauge.ListMap
     Gauge.Time
+    Gauge.Optional
     Gauge.CSV
 
     Gauge.Source.RUsage


### PR DESCRIPTION
This is a small framework to handle `Maybe a` in an efficient manner in term of representation by adding a tag to represent Nothing. Cleanup the `fromX` which doesn't use any type representation for this tagging and is thus error prone.

I originally planned something more complicated at the type level, but this is actually much simpler and handle what we need
 
fix #31 and related to #28