### PR TITLE
Re-export benchmark module from Main.

### DIFF
--- a/Gauge/Main.hs
+++ b/Gauge/Main.hs
@@ -23,6 +23,7 @@ module Gauge.Main
     -- * Running Benchmarks Interactively
     , benchmark
     , benchmarkWith
+    , module Gauge.Benchmark
     ) where
 
 import Control.Applicative


### PR DESCRIPTION
For compatibility purpose and easier migration, it's simpler to
re-export all the functions and types from the old packages
in the same way.