### PR TITLE
Change default benchmark match mode to exact match

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add a new benchmark matching option "-m exact" to match the benchmark name
+  exactly.
 * Write data to CSV file in quick mode too.
 * Fix the CSV file header to match with the data rows for the `--csvraw` case.
 


### PR DESCRIPTION
Earlier it was prefix and there was no way to run a single benchmark when one
benchmark in the file was a prefix of another.

fixes #80