### PR TITLE
Use "--match exact" option for isolated measurements

### DIFF
--- a/Gauge/Benchmark.hs
+++ b/Gauge/Benchmark.hs
@@ -604,6 +604,7 @@ runBenchmarkIsolated cfg prog desc =
       callProcess prog ([ "--time-limit", show (bmTimeLimit cfg)
                         , "--min-duration", show ms
                         , "--min-samples", show (bmMinSamples cfg)
+                        , "--match", "exact"
                         , "--measure-only", file, desc
                         ] ++ if (quickMode cfg) then ["--quick"] else [])
       meas <- readFile file >>= return . read


### PR DESCRIPTION
Isolated measurements run a single benchmark in an isolated process. The
default matching for gauge is "prefix" based which selects multiple benchmarks
when the benchmark name happens to be a prefix of other benchmarks.