### PR TITLE
Support benchmarking with GHCJS

### DIFF
--- a/Gauge/Source/GC.hs
+++ b/Gauge/Source/GC.hs
@@ -43,10 +43,14 @@ supported = unsafePerformIO (readIORef supportedVar)
 
 supportedVar :: IORef Bool
 supportedVar = unsafePerformIO $ do
+#if __GHCJS__
+    let b = False
+#else
 #if MIN_VERSION_base(4,10,0)
     b <- GHC.getRTSStatsEnabled
 #else
     b <- (const True <$> GHC.getGCStats) `Exn.catch` \(_ :: Exn.SomeException) -> pure False
+#endif
 #endif
     newIORef b
 {-# NOINLINE supportedVar #-}

--- a/Gauge/Source/GC.hs
+++ b/Gauge/Source/GC.hs
@@ -45,12 +45,10 @@ supportedVar :: IORef Bool
 supportedVar = unsafePerformIO $ do
 #if __GHCJS__
     let b = False
-#else
-#if MIN_VERSION_base(4,10,0)
+#elif MIN_VERSION_base(4,10,0)
     b <- GHC.getRTSStatsEnabled
 #else
     b <- (const True <$> GHC.getGCStats) `Exn.catch` \(_ :: Exn.SomeException) -> pure False
-#endif
 #endif
     newIORef b
 {-# NOINLINE supportedVar #-}

--- a/Gauge/Source/Time.hsc
+++ b/Gauge/Source/Time.hsc
@@ -80,15 +80,15 @@ withMetrics f = allocaBytes (sizeTimeRecord * 2) $ \ptr -> do
 data CTimespec = MkCTimespec CTime CLong
 
 instance Storable CTimespec where
-  sizeOf _ = 8
-  alignment _ = 4
-  peek p = do
-    s  <- peekByteOff p 0
-    ns <- peekByteOff p 4
-    return (MkCTimespec s ns)
-  poke p (MkCTimespec s ns) = do
-    pokeByteOff p 0 s
-    pokeByteOff p 4 ns
+    sizeOf _ = 8
+    alignment _ = 4
+    peek p = do
+      s  <- peekByteOff p 0
+      ns <- peekByteOff p 4
+      return (MkCTimespec s ns)
+    poke p (MkCTimespec s ns) = do
+      pokeByteOff p 0 s
+      pokeByteOff p 4 ns
 
 foreign import ccall unsafe "time.h clock_gettime"
     clock_gettime :: CInt -> Ptr CTimespec -> IO CInt
@@ -111,7 +111,7 @@ initialize :: IO ()
 initialize = return ()
 
 getCycles :: IO (Cycles 'Absolute)
-getCycles = undefined
+getCycles = error "GHCJS does not support measuring cycles"
 
 getTime :: IO Double
 getTime = do
@@ -124,7 +124,7 @@ getTime = do
     return $ fromIntegral sec + (fromIntegral nsec / 1000000000)
 
 getCPUTime :: IO Double
-getCPUTime = undefined
+getCPUTime = error "GHCJS does not support measuring CPUTime"
 
 #else
 

--- a/Gauge/Source/Time.hsc
+++ b/Gauge/Source/Time.hsc
@@ -4,6 +4,7 @@
 --
 -- Various system time gathering methods
 --
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE ForeignFunctionInterface   #-}
 {-# LANGUAGE KindSignatures             #-}
@@ -31,6 +32,10 @@ import Foreign.Ptr
 import Foreign.Storable
 import Foreign.Marshal.Alloc (alloca, allocaBytes)
 import Prelude -- Silence redundant import warnings
+
+#ifdef __GHCJS__
+import Foreign.C
+#endif
 
 data MeasurementType = Differential | Absolute
 
@@ -71,6 +76,58 @@ withMetrics f = allocaBytes (sizeTimeRecord * 2) $ \ptr -> do
     getRecordPtr ptr2
     (,,) <$> pure a <*> peek ptr <*> peek ptr2
 
+#ifdef __GHCJS__
+data CTimespec = MkCTimespec CTime CLong
+
+instance Storable CTimespec where
+  sizeOf _ = 8
+  alignment _ = 4
+  peek p = do
+    s  <- peekByteOff p 0
+    ns <- peekByteOff p 4
+    return (MkCTimespec s ns)
+  poke p (MkCTimespec s ns) = do
+    pokeByteOff p 0 s
+    pokeByteOff p 4 ns
+
+foreign import ccall unsafe "time.h clock_gettime"
+    clock_gettime :: CInt -> Ptr CTimespec -> IO CInt
+
+-- | Get the current POSIX time from the system clock.
+getRecordPtr :: Ptr (TimeRecord 'Absolute) -> IO ()
+getRecordPtr ptr = do
+    MkCTimespec (CTime sec) (CLong nsec) <-
+        alloca (\ptspec -> do
+            throwErrnoIfMinus1_ "clock_gettime" $
+                clock_gettime 0 ptspec
+            peek ptspec
+        )
+    poke ptr (TimeRecord 
+        (ClockTime ((fromIntegral sec) * 1000000000 + fromIntegral nsec))
+        (CpuTime 0)
+        (Cycles 0))
+
+initialize :: IO ()
+initialize = return ()
+
+getCycles :: IO (Cycles 'Absolute)
+getCycles = undefined
+
+getTime :: IO Double
+getTime = do
+    MkCTimespec (CTime sec) (CLong nsec) <-
+        alloca (\ptspec -> do
+            throwErrnoIfMinus1_ "clock_gettime" $
+                clock_gettime 0 ptspec
+            peek ptspec
+        )
+    return $ fromIntegral sec + (fromIntegral nsec / 1000000000)
+
+getCPUTime :: IO Double
+getCPUTime = undefined
+
+#else
+
 -- | Set up time measurement.
 foreign import ccall unsafe "gauge_inittime" initialize :: IO ()
 
@@ -89,3 +146,4 @@ foreign import ccall unsafe "gauge_getcputime" getCPUTime :: IO Double
 
 -- | Record clock, cpu and cycles in one structure
 foreign import ccall unsafe "gauge_record" getRecordPtr :: Ptr (TimeRecord 'Absolute) -> IO ()
+#endif

--- a/cabal.project.ghcjs
+++ b/cabal.project.ghcjs
@@ -1,0 +1,7 @@
+compiler: ghcjs
+packages: gauge.cabal
+
+source-repository-package
+  type: git
+  location: https://github.com/ghcjs/ghcjs-base
+  tag: b8d51f65ae1921b2f031710bf75e17f216de442a

--- a/cabal.project.ghcjs
+++ b/cabal.project.ghcjs
@@ -1,7 +1,0 @@
-compiler: ghcjs
-packages: gauge.cabal
-
-source-repository-package
-  type: git
-  location: https://github.com/ghcjs/ghcjs-base
-  tag: b8d51f65ae1921b2f031710bf75e17f216de442a

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add GHCJS support (statistical analysis is not supported)
+
 # 0.2.4
 
 * `Enhancement`: Add `nfAppIO` and `whnfAppIO` functions, which take a function

--- a/gauge.cabal
+++ b/gauge.cabal
@@ -54,7 +54,7 @@ library
     Gauge.Source.Time
     System.Random.MWC
 
-  if flag(analysis)
+  if flag(analysis) && !impl(ghcjs)
       exposed-modules:
         Gauge.Analysis
       other-modules:
@@ -111,7 +111,7 @@ library
 
   default-language: Haskell2010
   ghc-options: -O2 -Wall -funbox-strict-fields
-  if flag(analysis)
+  if flag(analysis) && !impl(ghcjs)
       cpp-options: -DHAVE_ANALYSIS
 
 test-suite sanity


### PR DESCRIPTION
I have disabled analysis support for GHCJS as it requires some C functions for
statistics. Though we can use javascript versions of those I did not spend the
effort to do that.

There is no CI script but it can be built using:

```
cabal new-bench --project-file cabal.project.ghcjs
```

We can then run the benchmarking executable manually using "node" or using a
browser:

```
node /vol/hosts/cueball/workspace/github/hs-gauge/dist-newstyle/build/x86_64-linux/ghcjs-8.6.0.1/gauge-0.2.4/b/self/build/self/self.jsexe/all.js
```