### PR TITLE
Invalid results with perRunEnv

### DIFF
--- a/Gauge/Measurement.hs
+++ b/Gauge/Measurement.hs
@@ -362,10 +362,9 @@ measureTime f = do
 -- | Invokes the supplied benchmark runner function with a combiner and a
 -- measurer that returns the measurement of a single iteration of an IO action.
 measure :: ((Measured -> Measured -> Measured)
-            -> (IO () -> IO Measured) -> IO Measured)
-        -> Int64         -- ^ Number of iterations.
+        -> (Int64 -> IO () -> IO Measured) -> IO Measured)
         -> IO Measured
-measure run iters = run addResults $ \act -> do
+measure run = run addResults $ \ !iters act -> do
 #ifdef GAUGE_MEASURE_TIME_NEW
     ((Time.TimeRecord time cpuTime cycles, startRUsage, endRUsage), gcStats) <- GC.withMetrics $ RUsage.with RUsage.Self $ measureTime act
 #else


### PR DESCRIPTION
Gauge has same bug as bos/criterion#174, this PR applies similar fix.

Program:
```
#!/usr/bin/env stack
-- stack runghc --package gauge

import Gauge.Main
import Control.Concurrent

main =
    defaultMain
      [
        bench "whnfIO" $ whnfIO $ threadDelay 100000,
        bench "perRunEnv" $ perRunEnv (return ()) $ \_ -> threadDelay 100000
      ]
```

Before:
```
whnfIO                                   mean 103.7 ms  ( +- 871.4 μs  )
perRunEnv                                mean 30.30 ms  ( +- 28.39 ms  )
```

After:
```
whnfIO                                   mean 103.4 ms  ( +- 1.098 ms  )
perRunEnv                                mean 104.0 ms  ( +- 683.6 μs  )
```
