### PR TITLE
export runBenchmarkable' from Gauge.Benchmark

### DIFF
--- a/Gauge/Benchmark.hs
+++ b/Gauge/Benchmark.hs
@@ -63,6 +63,7 @@ module Gauge.Benchmark
     -- * Running Benchmarks
     , runBenchmark
     , BenchmarkAnalysis(..)
+    , runBenchmarkable'
     ) where
 
 import Control.Applicative


### PR DESCRIPTION
Under the **Future Feature Plan** section of the README it says: _"Make the library more useful as a standalone library to gather benchmark numbers related to functions in a programatic way"_. This PR seeks to improve gauge in this regard.

My use case is that I want to write a performance test which asserts that some algorithm, applied to some input data, runs within some specified upper time bound.