### PR TITLE
Make C code work on Intel- and ARM-based Macs

### DIFF
--- a/cbits/cycles.c
+++ b/cbits/cycles.c
@@ -1,6 +1,15 @@
 #include "Rts.h"
 
-#if x86_64_HOST_ARCH || i386_HOST_ARCH
+#if darwin_HOST_OS
+
+#include <mach/mach_time.h>
+
+StgWord64 gauge_rdtsc(void)
+{
+  return mach_absolute_time();
+}
+
+#elif x86_64_HOST_ARCH || i386_HOST_ARCH
 
 StgWord64 gauge_rdtsc(void)
 {

--- a/cbits/time-osx.c
+++ b/cbits/time-osx.c
@@ -1,28 +1,10 @@
 #include <mach/mach.h>
-#include <mach/mach_time.h>
 
 #include "gauge-time.h"
 #include "cycles.h"
+#include <time.h>
 
-static mach_timebase_info_data_t timebase_info;
-static double timebase_recip;
-
-void gauge_inittime(void)
-{
-    if (timebase_recip == 0) {
-	mach_timebase_info(&timebase_info);
-	timebase_recip = (timebase_info.denom / timebase_info.numer) / 1e9;
-    }
-}
-
-static inline uint64_t scale64(uint64_t i, uint64_t numer, uint64_t denom)
-{
-    uint64_t high = (i >> 32) * numer;
-    uint64_t low = (i & 0xffffffffULL) * numer / denom;
-    uint64_t highRem = ((high % denom) << 32) / denom;
-    high /= denom;
-    return (high << 32) + highRem + low;
-}
+void gauge_inittime(void) {}
 
 void gauge_record(struct gauge_time *tr)
 {
@@ -32,7 +14,7 @@ void gauge_record(struct gauge_time *tr)
 				                 (task_info_t) &thread_info_data,
 				                 &thread_info_count);
 
-    tr->clock_nanosecs = scale64(mach_absolute_time(), timebase_info.numer, timebase_info.denom);
+    tr->clock_nanosecs = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 
     tr->cpu_nanosecs = (((uint64_t) thread_info_data.user_time.seconds) * ref_second) +
                        (((uint64_t) thread_info_data.user_time.microseconds) * ref_microsecond) +
@@ -43,7 +25,7 @@ void gauge_record(struct gauge_time *tr)
 
 double gauge_gettime(void)
 {
-    return mach_absolute_time() * timebase_recip;
+    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / 1e9;
 }
 
 static double to_double(time_value_t time)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,28 @@
+# next
+
+* Change `gauge_rdtsc` to return `mach_absolute_time` on macOS. This is a
+  portable way of returning the number of CPU cycles that works on both Intel-
+  and ARM-based Macs.
+
+* Change `gauge_gettime` to use `clock_gettime_nsec_np` instead of
+  `mach_absolute_time` on macOS. While `mach_absolute_time` has nanosecond
+  resolution on Intel-based Macs, this is not the case on ARM-based Macs, so
+  the previous `mach_absolute_time`-based implementation would return incorrect
+  timing results on Apple silicon.
+
+  There are two minor consequences of this change:
+
+  * Gauge now only supports macOS 10.02 or later, as that is
+    the first version to have `clock_gettime_nsec_np`. As macOS 10.02 was
+    released in 2002, this is unlikely to affect users, but please speak up if
+    this is a problem for you.
+
+  * As `clock_gettime_nsec_np` does not require any special initialization
+    code, `gauge_inittime` is now a no-op on macOS. If you manually invoke
+    the `getTime` function in your code, however, it is still important that
+    you `initializeTime` beforehand, as this is still required for the Windows
+    implementation to work correctly.
+
 # 0.2.5
 
 * Add GHCJS support (statistical analysis is not supported)


### PR DESCRIPTION
This applies two tweaks to `cycles.c` and `time-osx.c` to ensure that
`gauge_rdtsc` and `gauge_gettime` work on all versions of macOS,
regardless of the architecture being used. In particular, this is required to
make Gauge compile and run on Apple silicon.

Fixes #104.

Original-patch-by: Ryan Scott <ryan.gl.scott@gmail.com> (haskell/criterion#240)